### PR TITLE
VP-5059: Fix getCommitCount fail on PR

### DIFF
--- a/add-version-suffix/index.js
+++ b/add-version-suffix/index.js
@@ -22,7 +22,7 @@ async function getCommitCount(baseBranch) {
         //options.cwd = './';
 
         //await exec.exec(`${src}/commit-count.sh`, [baseBranch], options);f
-        await exec.exec(`git rev-list --count ${baseBranch}`, [], options).then(exitCode => console.log(`git rev-list --count exitCode: ${exitCode}`));
+        await exec.exec(`git rev-list --count origin/${baseBranch}`, [], options).then(exitCode => console.log(`git rev-list --count exitCode: ${exitCode}`));
         const commitCount = output.trim();
 
         if (commitCount) {


### PR DESCRIPTION
### Problem
Module workflow fial on Add version suffix action on PR
![image](https://user-images.githubusercontent.com/44946644/97275849-089be800-1869-11eb-98b4-8aa69f12b125.png)

https://github.com/VirtoCommerce/vc-module-demo-features/pull/18/checks?check_run_id=1313471818

### Solution
Add `origin/` prefix to branch name on commit count
