### PR TITLE
VP-5059: Fix release alpha

### DIFF
--- a/deploy-workflow/workflows/modules/.github/workflows/release-alpha.yml
+++ b/deploy-workflow/workflows/modules/.github/workflows/release-alpha.yml
@@ -1,4 +1,4 @@
-# v1
+# v1.1.1
 name: Module Release alpha CI
 
 on:
@@ -24,8 +24,16 @@ jobs:
       - name: Install dotnet-sonarscanner
         run: dotnet tool install --global dotnet-sonarscanner
 
+      - name: Get Image Version
+        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        id: image
+        with:
+           releaseBranch: '' #Always creates tags for alpha version regardless of the forced branch
+
       - name: Add version suffix
         uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
+        with:
+          versionSuffix: ${{ steps.image.outputs.suffix }}
 
       - name: SonarCloud Begin
         uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master
@@ -43,7 +51,6 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/sonar-quality-gate@master
         with:
           login: ${{secrets.SONAR_TOKEN}}
-          projectKey: "VirtoCommerce_vc-module-demo-features"
 
       - name: Packaging
         run: vc-build Compress -skip Clean+Restore+Compile+Test

--- a/deploy-workflow/workflows/platform/.github/workflows/release-alpha.yml
+++ b/deploy-workflow/workflows/platform/.github/workflows/release-alpha.yml
@@ -1,7 +1,8 @@
-# v1
+# v1.1.1
 name: Platform Release alpha CI
 on:
   workflow_dispatch:
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -25,9 +26,13 @@ jobs:
     - name: Get Image Version
       uses: VirtoCommerce/vc-github-actions/get-image-version@master
       id: image
+      with:
+        releaseBranch: '' #Always creates tags for alpha version regardless of the forced branch
 
     - name: Add version suffix
       uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
+      with:
+        versionSuffix: ${{ steps.image.outputs.suffix }}
 
     - name: SonarCloud Begin
       uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master

--- a/deploy-workflow/workflows/storefront/.github/workflows/release-alpha.yml
+++ b/deploy-workflow/workflows/storefront/.github/workflows/release-alpha.yml
@@ -1,4 +1,4 @@
-# v1
+# v1.1.1
 name: Storefront Release alpha CI
 
 on:
@@ -27,9 +27,13 @@ jobs:
       - name: Get Image Version
         uses: VirtoCommerce/vc-github-actions/get-image-version@master
         id: image
+        with:
+           releaseBranch: '' #Always creates tags for alpha version regardless of the forced branch
 
       - name: Add version suffix
         uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
+        with:
+          versionSuffix: ${{ steps.image.outputs.suffix }}
 
       - name: SonarCloud Begin
         uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master

--- a/deploy-workflow/workflows/themes/.github/workflows/release-alpha.yml
+++ b/deploy-workflow/workflows/themes/.github/workflows/release-alpha.yml
@@ -23,6 +23,8 @@ jobs:
     - name: Get Image Version
       uses: VirtoCommerce/vc-github-actions/get-image-version@master
       id: image
+      with:
+        releaseBranch: '' #Always creates tags for alpha version regardless of the forced branch
 
     - name: Get changelog
       id: changelog

--- a/get-image-version/action.yml
+++ b/get-image-version/action.yml
@@ -5,9 +5,9 @@ inputs:
     description: 'Path to directory that contains module.manifest, package.json or Directory.Build.props'
     required: false
   releaseBranch: 
-    description: "Branch support preparation of a new production release"
+    description: 'Branch support preparation of a new production release'
     required: false
-    default: "master"
+    default: 'master'
 
 outputs:
   branchName:

--- a/get-image-version/index.js
+++ b/get-image-version/index.js
@@ -135,7 +135,7 @@ function tryGetInfoFromDirectoryBuildProps() {
 function pushOutputs(branchName, prefix, suffix, moduleId) {
     branchName = branchName.substring(branchName.lastIndexOf('/') + 1, branchName.length).toLowerCase();
     const sha = github.context.eventName.startsWith('pull_request') ? github.context.payload.pull_request.head.sha.substring(0, 8) : github.context.sha.substring(0, 8);
-    const fullSuffix = (suffix.length > 0) ? suffix + '-' + branchName : branchName;
+    const fullSuffix = (suffix) ? suffix + '-' + branchName : branchName;
     const shortVersion = prefix + '-' + suffix;
     const tag = prefix + '-' + branchName + '-' + sha;
     const fullVersion = prefix + '-' + fullSuffix;

--- a/get-image-version/index.js
+++ b/get-image-version/index.js
@@ -135,7 +135,7 @@ function tryGetInfoFromDirectoryBuildProps() {
 function pushOutputs(branchName, prefix, suffix, moduleId) {
     branchName = branchName.substring(branchName.lastIndexOf('/') + 1, branchName.length).toLowerCase();
     const sha = github.context.eventName.startsWith('pull_request') ? github.context.payload.pull_request.head.sha.substring(0, 8) : github.context.sha.substring(0, 8);
-    const fullSuffix = suffix + '-' + branchName;
+    const fullSuffix = (suffix.length > 0) ? suffix + '-' + branchName : branchName;
     const shortVersion = prefix + '-' + suffix;
     const tag = prefix + '-' + branchName + '-' + sha;
     const fullVersion = prefix + '-' + fullSuffix;


### PR DESCRIPTION
### Problem
1. When release-alpha workflow runs in the release branch,  artifacts creates with not alpha version names but with alpha version content
2. Tags for the release version incorrect: `3.27.0--master-26ef17e6` should be `3.27.0-master-26ef17e6`
