### PR TITLE
PT-1269: Fix branch naming for sonar

### DIFF
--- a/sonar-theme/action.yml
+++ b/sonar-theme/action.yml
@@ -1,10 +1,15 @@
 name: 'sonar-theme'
-description: 'SonarQube Analisys'
+description: 'SonarQube Analysis'
 inputs:
   projectVersion:
     default: ""
     required: false
-    description: "Theme verison"
+    description: "Theme version"
+  branchTarget:
+    default: "dev"
+    required: true
+    description: "Target branch name for sonar branch analysis"
+
 runs:
   using: 'node12'
   main: 'index.js'

--- a/sonar-theme/index.js
+++ b/sonar-theme/index.js
@@ -6,19 +6,24 @@ const { runInContext } = require('vm');
 
 async function run()
 {
+    const projectVersion = core.getInput("projectVersion");
+    const branchTarget = core.getInput("branchTarget");
+
+    const sonarLongLiveBranches = ["master","develop","dev"];
+
     let isPullRequest = await utils.isPullRequest(github);
     let branchName = await utils.getBranchName(github);
     let repoName = await utils.getRepoName();
     let projectKey = process.env.GITHUB_REPOSITORY.replace('/', '_');
-    let projectVersion = core.getInput("projectVersion");
     let projectVersionArg = projectVersion ? `-Dsonar.projectVersion=${projectVersion}` : "";
+    let branchTargetArg = sonarLongLiveBranches.includes(branchName) ? "" : `-Dsonar.branch.target=${branchTarget}`;
 
     if(isPullRequest)
     {
         let prTitle = github.context.payload.pull_request.title.split("\"").join("");
-        await exec.exec(`sonar-scanner -Dsonar.projectKey=${projectKey} -Dsonar.projectName=${repoName} -Dsonar.organization=virto-commerce -Dsonar.login=${process.env.SONAR_TOKEN} ${projectVersionArg} -Dsonar.host.url=https://sonarcloud.io -Dsonar.pullrequest.base=\"${github.context.payload.pull_request.base.ref}\" -Dsonar.pullrequest.branch=\"${prTitle}\" -Dsonar.pullrequest.key=\"${github.context.payload.pull_request.number}\" -Dsonar.pullrequest.github.repository=\"${process.env.GITHUB_REPOSITORY}\" -Dsonar.pullrequest.provider=GitHub -Dsonar.branch=${branchName}`);
+        await exec.exec(`sonar-scanner -Dsonar.projectKey=${projectKey} -Dsonar.projectName=${repoName} -Dsonar.organization=virto-commerce -Dsonar.login=${process.env.SONAR_TOKEN} ${projectVersionArg} -Dsonar.host.url=https://sonarcloud.io -Dsonar.pullrequest.base=\"${github.context.payload.pull_request.base.ref}\" -Dsonar.pullrequest.branch=\"${prTitle}\" -Dsonar.pullrequest.key=\"${github.context.payload.pull_request.number}\" -Dsonar.pullrequest.github.repository=\"${process.env.GITHUB_REPOSITORY}\" -Dsonar.pullrequest.provider=GitHub`);
     } else {
-        await exec.exec(`sonar-scanner -Dsonar.projectKey=${projectKey} -Dsonar.projectName=${repoName} -Dsonar.organization=virto-commerce -Dsonar.login=${process.env.SONAR_TOKEN} ${projectVersionArg} -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch=${branchName}`);
+        await exec.exec(`sonar-scanner -Dsonar.projectKey=${projectKey} -Dsonar.projectName=${repoName} -Dsonar.organization=virto-commerce -Dsonar.login=${process.env.SONAR_TOKEN} ${projectVersionArg} -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch.name=${branchName} ${branchTargetArg}`);
     }
 }
 


### PR DESCRIPTION
SonarCloud has changed parameters for branch analysis.
sonar.branch.name sonar.branch.terget should be specified in
sonarscanner command line now.
Added branchTarget with dev default value as input parameter
for sonar-theme action to handle sonar.branch.terget sonar parameter