### PR TITLE
PT-2023: Add PR labeles check condition for sonar actions

### DIFF
--- a/sonar-scanner-begin/index.js
+++ b/sonar-scanner-begin/index.js
@@ -6,6 +6,7 @@ const utils = require('@virtocommerce/vc-actions-lib');
 async function run()
 {
     let isPullRequest = await utils.isPullRequest(github);
+    let isDependencies = await utils.isDependencies(github);
 
     let prArg = isPullRequest ? '-PullRequest' : '';
     let branchName = await utils.getBranchName(github);
@@ -15,6 +16,12 @@ async function run()
     let prKeyArg = "";
     let ghRepoArg = "";
     let prProviderArg = "";
+
+    if (isPullRequest && isDependencies) {
+        console.log(`Pull request contain "dependencies" label, SonarScanner steps skipped.`);
+        return;
+    }
+
     if(isPullRequest)
     {
         prBaseArg = `-SonarPRBase "${github.context.payload.pull_request.base.ref}"`;

--- a/sonar-scanner-end/index.js
+++ b/sonar-scanner-end/index.js
@@ -14,7 +14,6 @@ async function run()
     }
 
     delete process.env.JAVA_TOOL_OPTIONS;
-    process.env
     await exec.exec(`vc-build SonarQubeEnd -SonarAuthToken ${process.env.SONAR_TOKEN} -skip`)
 }
 

--- a/sonar-scanner-end/index.js
+++ b/sonar-scanner-end/index.js
@@ -1,10 +1,18 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 const exec = require('@actions/exec');
+const utils = require('@virtocommerce/vc-actions-lib');
 
 async function run()
 {
-    //vc-build SonarQubeEnd -SonarAuthToken ${{ secrets.SONAR_TOKEN }} -skip
+    let isPullRequest = await utils.isPullRequest(github);
+    let isDependencies = await utils.isDependencies(github);
+
+    if (isPullRequest && isDependencies) {
+        console.log(`Pull request contain "dependencies" label, SonarScanner steps skipped.`);
+        return;
+    }
+
     delete process.env.JAVA_TOOL_OPTIONS;
     process.env
     await exec.exec(`vc-build SonarQubeEnd -SonarAuthToken ${process.env.SONAR_TOKEN} -skip`)

--- a/sonar-theme/index.js
+++ b/sonar-theme/index.js
@@ -12,11 +12,18 @@ async function run()
     const sonarLongLiveBranches = ["master","develop","dev"];
 
     let isPullRequest = await utils.isPullRequest(github);
+    let isDependencies = await utils.isDependencies(github);
+
     let branchName = await utils.getBranchName(github);
     let repoName = await utils.getRepoName();
     let projectKey = process.env.GITHUB_REPOSITORY.replace('/', '_');
     let projectVersionArg = projectVersion ? `-Dsonar.projectVersion=${projectVersion}` : "";
     let branchTargetArg = sonarLongLiveBranches.includes(branchName) ? "" : `-Dsonar.branch.target=${branchTarget}`;
+
+    if (isPullRequest && isDependencies) {
+        console.log(`Pull request contain "dependencies" label, SonarScanner steps skipped.`);
+        return;
+    }
 
     if(isPullRequest)
     {

--- a/vc-actions-lib/index.js
+++ b/vc-actions-lib/index.js
@@ -5,6 +5,8 @@ const { request } = require("@octokit/request");
 const glob = require('glob');
 const xml2js = require('xml2js');
 
+const DEPENDENCIES_LABEL = 'dependencies';
+
 async function findArtifact(pattern)
 {
     let globResult = glob.sync(pattern);
@@ -73,6 +75,14 @@ async function isPullRequest(github)
 {
     return github.context.eventName === 'pull_request';
 }
+
+async function isDependencies(github)
+{
+    return github.context.payload.pull_request.labels.some(
+        (label) => label.name === DEPENDENCIES_LABEL
+      );
+}
+
 
 function getVersionFromDirectoryBuildProps(path) {
     return new Promise((resolve) => {
@@ -204,6 +214,7 @@ module.exports.getRepoName = getRepoName;
 module.exports.getProjectType = getProjectType;
 module.exports.downloadFile = downloadFile;
 module.exports.isPullRequest = isPullRequest;
+module.exports.isDependencies = isDependencies;
 module.exports.getVersionFromDirectoryBuildProps = getVersionFromDirectoryBuildProps;
 module.exports.getInfoFromDirectoryBuildProps = getInfoFromDirectoryBuildProps;
 module.exports.getInfoFromModuleManifest = getInfoFromModuleManifest;

--- a/vc-actions-lib/index.js
+++ b/vc-actions-lib/index.js
@@ -83,7 +83,6 @@ async function isDependencies(github)
       );
 }
 
-
 function getVersionFromDirectoryBuildProps(path) {
     return new Promise((resolve) => {
         let buildPropsFile = path;


### PR DESCRIPTION
* Add isDependencies function to vc-actions-lib to check PR labels

* Skip sonar scanner step if PR contain dependencies label due to error
raised by dependabot