### PR TITLE
PT-7166: Override platform default setting in docker for autotest purpose

### DIFF
--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -48,6 +48,11 @@ inputs:
     description: 'Enable or disable "Install Sample Data" step'
     required: true
     default: 'true'
+  envDir:
+    description: 'Directory with environment files'
+    required: true
+    default: '.'
+
 
 runs:
   using: "composite"
@@ -82,18 +87,13 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
-        pushd ..
-        ls -l
-        popd    
-        ls - l ../.docker
-        cat ../.docker/platform.env
-        mkdir -p ../.docker
-        touch ../.docker/platform.env
-        touch ../.docker/storefront.env 
+        mkdir -p ${{ inputs.envDir }}/.docker
+        touch ${{ inputs.envDir }}/.docker/platform.env
+        touch ${{ inputs.envDir }}/.docker/storefront.env 
         echo -e 'Platform environment variables:'
-        cat ../.docker/platform.env
+        cat ${{ inputs.envDir }}/.docker/platform.env
         echo -e 'Storefront environment variables:'
-        cat ../.docker/storefront.env
+        cat ${{ inputs.envDir }}/.docker/storefront.env
 
     - name: Start containers
       env:
@@ -101,6 +101,7 @@ runs:
         STOREFRONT_IMAGE: ${{ inputs.storefrontImage }}
         PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
         STOREFRONT_DOCKER_TAG: ${{ inputs.storefrontDockerTag }}
+        ENV_DIR: ${{ inputs.envDir }}
       shell: pwsh
       working-directory: ${{ github.action_path }}
       run: |

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,13 +87,13 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        cat <<EOT >> ./platform.env
+        cat <<EOT >>./platform.env
         ${{ inputs.customPlatformSettings }}
         EOT 
-        cat <<EOT >> ./storefront.env
+        cat ./platform.env 
+        cat <<EOT >>./storefront.env
         ${{ inputs.customSorefrontSettings }}
         EOT
-        cat ./platform.env 
         cat ./storefront.env 
 
     - name: Start containers

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,6 +82,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
+        ls -l
         mkdir -p ./.docker
         touch ./.docker/platform.env
         touch ./.docker/storefront.env 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -88,7 +88,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo -e '\033[33mSave .env files started.'
+        echo -e '\033[33m.env files started.'
         mkdir -p ${{ inputs.envDir }}/.docker
         touch ${{ inputs.envDir }}/.docker/platform.env
         touch ${{ inputs.envDir }}/.docker/storefront.env 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,13 +82,13 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
-        mkdir -p ./docker
-        touch ./docker/platform.env
-        touch ./storefront.env 
+        mkdir -p ./.docker
+        touch ./.docker/platform.env
+        touch ./.docker/storefront.env 
         echo -e 'Platform environment variables:'
-        cat ./platform.env
+        cat ./.docker/platform.env
         echo -e 'Storefront environment variables:'
-        cat ./docker/storefront.env
+        cat ./.docker/storefront.env
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -92,10 +92,12 @@ runs:
         cat <<EOT >>./platform.env
         ${{ inputs.customPlatformSettings }}
         EOT 
+
         cat ./platform.env 
         cat <<EOT >>./storefront.env
         ${{ inputs.customSorefrontSettings }}
         EOT
+
         cat ./storefront.env 
 
     - name: Start containers

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,6 +82,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
+        cd ..
         ls -l
         mkdir -p ./.docker
         touch ./.docker/platform.env

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -77,11 +77,12 @@ runs:
         . "./scripts/install-custom-module.ps1"
         InstallCustomModule -InstallFolder ${{ env.INSTALL_FOLDER }} -CustomModuleId ${{ inputs.customModuleId }} -CustomModuleUrl ${{ inputs.customModuleUrl }}
 
-    - name: Save .env files
+    - name:  .env files
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
+        mkdir -p ./docker
         touch ./docker/platform.env
         touch ./storefront.env 
         echo -e 'Platform environment variables:'

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -48,12 +48,6 @@ inputs:
     description: 'Enable or disable "Install Sample Data" step'
     required: true
     default: 'true'
-  customPlatformSettings:
-    description: 'Override the default platform settings'
-    required: false
-  customSorefrontSettings:
-    description: 'Override the default storefront settings'
-    required: false
 
 runs:
   using: "composite"
@@ -88,17 +82,12 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
-        # cat ./platform.env
-        # cat <<EOT >>./platform.env
-        # ${{ inputs.customPlatformSettings }}
-        # EOT 
-
-        # cat ./platform.env 
-        # cat <<EOT >>./storefront.env
-        # ${{ inputs.customSorefrontSettings }}
-        # EOT
-
-        # cat ./storefront.env 
+        touch ./docker/platform.env
+        touch ./storefront.env 
+        echo -e 'Platform environment variables:'
+        cat ./platform.env
+        echo -e 'Storefront environment variables:'
+        cat ./docker/storefront.env
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -48,6 +48,12 @@ inputs:
     description: 'Enable or disable "Install Sample Data" step'
     required: true
     default: 'true'
+  customPlatformSettings:
+    description: 'Override the default platform settings'
+    required: false
+  customSorefrontSettings:
+    description: 'Override the default storefront settings'
+    required: false
 
 runs:
   using: "composite"
@@ -76,6 +82,15 @@ runs:
         Write-Host "`e[33mInstall Custom Module started."
         . "./scripts/install-custom-module.ps1"
         InstallCustomModule -InstallFolder ${{ env.INSTALL_FOLDER }} -CustomModuleId ${{ inputs.customModuleId }} -CustomModuleUrl ${{ inputs.customModuleUrl }}
+
+    - name: Save .env files
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        ${{ inputs.customPlatformSettings }} >> platform.env
+        ${{ inputs.customSorefrontSettings }} >> storefront.env
+        cat platform.env 
+        cat storefront.env 
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,6 +87,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
+        echo "`e[33mSave .env files started."
+        cat ./platform.env
         cat <<EOT >>./platform.env
         ${{ inputs.customPlatformSettings }}
         EOT 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,8 +87,8 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        ${{ inputs.customPlatformSettings }} >> platform.env
-        ${{ inputs.customSorefrontSettings }} >> storefront.env
+        "${{ inputs.customPlatformSettings }}" >> platform.env
+        "${{ inputs.customSorefrontSettings }}" >> storefront.env
         cat platform.env 
         cat storefront.env 
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,8 +87,12 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        "${{ inputs.customPlatformSettings }}" >> platform.env
-        "${{ inputs.customSorefrontSettings }}" >> storefront.env
+        cat <<EOT >> platform.env
+        ${{ inputs.customPlatformSettings }}
+        EOT 
+        cat <<EOT >> storefront.env
+        ${{ inputs.customSorefrontSettings }}
+        EOT
         cat platform.env 
         cat storefront.env 
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,15 +82,13 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
-        cd ..
-        ls -l
-        mkdir -p ./.docker
-        touch ./.docker/platform.env
-        touch ./.docker/storefront.env 
+        mkdir -p ../.docker
+        touch ../.docker/platform.env
+        touch ../.docker/storefront.env 
         echo -e 'Platform environment variables:'
-        cat ./.docker/platform.env
+        cat ../.docker/platform.env
         echo -e 'Storefront environment variables:'
-        cat ./.docker/storefront.env
+        cat ../.docker/storefront.env
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,14 +87,14 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        cat <<EOT >> platform.env
+        cat <<EOT >> ./platform.env
         ${{ inputs.customPlatformSettings }}
         EOT 
-        cat <<EOT >> storefront.env
+        cat <<EOT >> ./storefront.env
         ${{ inputs.customSorefrontSettings }}
         EOT
-        cat platform.env 
-        cat storefront.env 
+        cat ./platform.env 
+        cat ./storefront.env 
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,7 +87,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo "`e[33mSave .env files started."
+        echo "\033[33mSave .env files started."
         cat ./platform.env
         cat <<EOT >>./platform.env
         ${{ inputs.customPlatformSettings }}

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -87,7 +87,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        echo "\033[33mSave .env files started."
+        echo -e '\033[33mSave .env files started.'
         cat ./platform.env
         cat <<EOT >>./platform.env
         ${{ inputs.customPlatformSettings }}

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,6 +82,9 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
+        pushd ..
+        ls -l
+        popd    
         ls - l ../.docker
         cat ../.docker/platform.env
         mkdir -p ../.docker

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -88,17 +88,17 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
-        cat ./platform.env
-        cat <<EOT >>./platform.env
-        ${{ inputs.customPlatformSettings }}
-        EOT 
+        # cat ./platform.env
+        # cat <<EOT >>./platform.env
+        # ${{ inputs.customPlatformSettings }}
+        # EOT 
 
-        cat ./platform.env 
-        cat <<EOT >>./storefront.env
-        ${{ inputs.customSorefrontSettings }}
-        EOT
+        # cat ./platform.env 
+        # cat <<EOT >>./storefront.env
+        # ${{ inputs.customSorefrontSettings }}
+        # EOT
 
-        cat ./storefront.env 
+        # cat ./storefront.env 
 
     - name: Start containers
       env:

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -83,6 +83,7 @@ runs:
       run: |
         echo -e '\033[33mSave .env files started.'
         ls - l ../.docker
+        cat ../.docker/platform.env
         mkdir -p ../.docker
         touch ../.docker/platform.env
         touch ../.docker/storefront.env 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -83,6 +83,8 @@ runs:
         InstallCustomModule -InstallFolder ${{ env.INSTALL_FOLDER }} -CustomModuleId ${{ inputs.customModuleId }} -CustomModuleUrl ${{ inputs.customModuleUrl }}
 
     - name:  .env files
+      env:
+        ENV_DIR: ${{ inputs.envDir }}
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -82,6 +82,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo -e '\033[33mSave .env files started.'
+        ls - l ../.docker
         mkdir -p ../.docker
         touch ../.docker/platform.env
         touch ../.docker/storefront.env 

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     env_file:
-      - ../.docker/platform.env
+      - ${ENV_DIR:-.}/.docker/platform.env
     environment:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
@@ -58,7 +58,7 @@ services:
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
     env_file:
-      - ../.docker/storefront.env
+      - ${ENV_DIR:-.}/.docker/storefront.env
     environment:
       - VirtoCommerce:Endpoint:Url=http://vc-platform-web
       - VirtoCommerce:Endpoint:UserName=admin

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     env_file:
-      - ./.docker/platform.env
+      - ../.docker/platform.env
     environment:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
@@ -58,7 +58,7 @@ services:
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
     env_file:
-      - ./.docker/storefront.env
+      - ../.docker/storefront.env
     environment:
       - VirtoCommerce:Endpoint:Url=http://vc-platform-web
       - VirtoCommerce:Endpoint:UserName=admin

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     env_file:
-      - ./docker/platform.env
+      - ./.docker/platform.env
     environment:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
@@ -58,7 +58,7 @@ services:
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
     env_file:
-      - ./docker/storefront.env
+      - ./.docker/storefront.env
     environment:
       - VirtoCommerce:Endpoint:Url=http://vc-platform-web
       - VirtoCommerce:Endpoint:UserName=admin

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     env_file:
-      - platform.env
+      - ./docker/platform.env
     environment:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
@@ -58,7 +58,7 @@ services:
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
     env_file:
-      - storefront.env
+      - ./docker/storefront.env
     environment:
       - VirtoCommerce:Endpoint:Url=http://vc-platform-web
       - VirtoCommerce:Endpoint:UserName=admin

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     image: ${PLATFORM_IMAGE:-virtocommerce/platform}:${PLATFORM_DOCKER_TAG:-latest}
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
+    env_file:
+      - platform.env
     environment:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
@@ -55,6 +57,8 @@ services:
     image: ${STOREFRONT_IMAGE:-virtocommerce/storefront}:${STOREFRONT_DOCKER_TAG:-latest}
     ports:
       - "${DOCKER_STOREFRONT_PORT:-8080}:80"
+    env_file:
+      - storefront.env
     environment:
       - VirtoCommerce:Endpoint:Url=http://vc-platform-web
       - VirtoCommerce:Endpoint:UserName=admin

--- a/docker-env/platform.env
+++ b/docker-env/platform.env
@@ -1,0 +1,1 @@
+Search__OrderFullTextSearchEnabled="true"

--- a/docker-env/platform.env
+++ b/docker-env/platform.env
@@ -1,1 +1,0 @@
-Search__OrderFullTextSearchEnabled="true"


### PR DESCRIPTION
To override default platform or storefront settings, place `platform.env` or `storefront.env` environment variables files in `.docker` folder in your repository. `.docker` folder should  be placed at the root of your repository (the same level as `.github` folder) 

Relative path should look like `{repo_name}/.docker/platform.env` or `{repo_name}/.docker/storefront.env`. 

 `platform.env` or `storefront.env` files shouuld be formated  with docker comose .env file [syntax rules](https://docs.docker.com/compose/env-file/#syntax-rules)

Example 
`Search__OrderFullTextSearchEnabled=true`



