### PR TITLE
VCST-861: Fix add empty line to Jira links

### DIFF
--- a/publish-jira-link/action.yml
+++ b/publish-jira-link/action.yml
@@ -18,7 +18,7 @@ inputs:
   downloadComment:
     description: "Comment template"
     required: false
-    default: "Jira-link:"
+    default: "Jira-link:\r"
 runs:
   using: 'node20'
   main: 'dist/index.js' 

--- a/publish-jira-link/src/index.ts
+++ b/publish-jira-link/src/index.ts
@@ -31,7 +31,7 @@ async function run(): Promise<void> {
     let body = currentPr.data.body ?? "";
 
     const jiraLinks = jiraKeys.map((key) => baseUrl.concat(key)).filter((jiraLink) => !body.includes(jiraLink));
-    const publishString = downloadComment.concat("\n").concat(jiraLinks.join("\n"));
+    const publishString = downloadComment.concat(jiraLinks);
 
     if (body.includes(downloadComment)) {
         body = body.replace(downloadComment, publishString);


### PR DESCRIPTION
Fixed adding an empty string after `### Jira-link:` on every commit to open PR.
https://virtocommerce.atlassian.net/browse/VCST-861