### PR TITLE
VCST-571: Fix for `non-existent` release branch

### DIFF
--- a/cloud-create-deploy-matrix/dist/index.js
+++ b/cloud-create-deploy-matrix/dist/index.js
@@ -9677,6 +9677,9 @@ function run() {
                     releaseBranch = "master";
                 }
             }
+            else {
+                releaseBranch = core.getInput("releaseBranch");
+            }
             if (github.context.ref.indexOf(releaseBranch) > -1) {
                 environment = { envName: "prod", confPath: confPath, forceCommit: "true", releaseType: githubReleases };
                 environments.push(environment);

--- a/cloud-create-deploy-matrix/src/index.ts
+++ b/cloud-create-deploy-matrix/src/index.ts
@@ -18,7 +18,7 @@ async function run(): Promise<void> {
         } else {
             releaseBranch = "master";
         }
-    }
+    } else {releaseBranch = core.getInput("releaseBranch")}
     
     // Create a deployment matrix for dev only
 


### PR DESCRIPTION
Fix for the case when workflow cloud-create-deploy-matrix is called with `releaseBranch` != `master`.
