### PR TITLE
VCST-1253: Fix release branch input name

### DIFF
--- a/publish-docker-image/index.js
+++ b/publish-docker-image/index.js
@@ -45,7 +45,7 @@ async function run()
     const dockerOrg = core.getInput("dockerOrg");
 
     let releaseBranch = "";
-    if ( core.getInput("releaseBranch") === "master"){
+    if ( core.getInput("release_Branch") === "master"){
         let actualBranch = github.context.ref;
         if (actualBranch === "refs/heads/main"){
             releaseBranch = "main";


### PR DESCRIPTION
Fix input's name to correctly form image tag for release branch.