### PR TITLE
VCST-1617: Fix docker compose

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -28,8 +28,8 @@ jobs:
         id: containers
         shell: pwsh
         run: |
-          $platformIP = docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' virtocommerce_vc-platform-web_1
-          $storefrontIP = docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' virtocommerce_vc-storefront-web_1
+          $platformIP = docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' virtocommerce-vc-platform-web-1
+          $storefrontIP = docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' virtocommerce-vc-storefront-web-1
           Write-Output "Platform ip: $($platformIP). Storefront ip: $($storefrontIP)"
           Write-Output "::set-output name=platformIP::$($platformIP)"
           Write-Output "::set-output name=storefrontIP::$($storefrontIP)"

--- a/docker-check-modules/scripts/check-installed-modules.ps1
+++ b/docker-check-modules/scripts/check-installed-modules.ps1
@@ -28,7 +28,7 @@ function Get-AuthToken {
 
 Start-Sleep -Seconds 30
 docker ps -a
-docker logs virtocommerce_vc-platform-web_1
+docker logs virtocommerce-vc-platform-web-1
 Write-Output $appAuthUrl
 Write-Output $checkModulesUrl
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -107,7 +107,7 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         Write-Host "`e[33mStart Containers step started."
-        $platformContainer = "virtocommerce_vc-platform-web_1"
+        $platformContainer = "virtocommerce-vc-platform-web-1"
         . ./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
 
         docker compose --project-name virtocommerce up -d
@@ -122,7 +122,7 @@ runs:
       shell: pwsh
       run: |
         Write-Host "`e[33mCheck Installed Modules step started."
-        $platformContainer = "virtocommerce_vc-platform-web_1"
+        $platformContainer = "virtocommerce-vc-platform-web-1"
         scripts/check-installed-modules.ps1 -ApiUrl http://localhost:8090 -ContainerId $platformContainer
         Write-Host "`e[32mInstalled Modules checked."
 
@@ -140,7 +140,7 @@ runs:
       run: |
         $waitForSwaggerSec = 30
         Write-Host "`e[33mSwagger Schema Validation step started."
-        $platformContainer = "virtocommerce_vc-platform-web_1"
+        $platformContainer = "virtocommerce-vc-platform-web-1"
         . "${{ github.action_path }}/scripts/watch-url-up.ps1"
         $platformIsUp = (Watch-Url-Up -ApiUrl http://localhost:8090 -TimeoutMinutes 15 -RetrySeconds 15 -WaitSeconds 0 -ContainerId $platformContainer)
         if ($platformIsUp) {

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -110,7 +110,7 @@ runs:
         $platformContainer = "virtocommerce_vc-platform-web_1"
         . "./scripts/inspect-docker-status.ps1"
 
-        docker-compose --project-name virtocommerce up -d
+        docker compose --project-name virtocommerce up -d
 
         InspectContainerStatus -ContainerId $platformContainer
         

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -112,7 +112,7 @@ runs:
 
         docker compose --project-name virtocommerce up -d
 
-        InspectContainerStatus -ContainerId $platformContainer
+        InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0
         
         Write-Host "`e[32mContainers started."
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -108,7 +108,7 @@ runs:
       run: |
         Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce_vc-platform-web_1"
-        pwsh -File "./scripts/inspect-docker-status.ps1" -ContainerId "$platformContainer"
+        . ./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
 
         docker compose --project-name virtocommerce up -d
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -108,7 +108,7 @@ runs:
       run: |
         Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce_vc-platform-web_1"
-        . "./scripts/inspect-docker-status.ps1"
+        . "./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer"
 
         docker compose --project-name virtocommerce up -d
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -108,7 +108,7 @@ runs:
       run: |
         Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce_vc-platform-web_1"
-        . "./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer"
+        pwsh -File "./scripts/inspect-docker-status.ps1" -ContainerId "$platformContainer"
 
         docker compose --project-name virtocommerce up -d
 

--- a/docker-env/scripts/check-installed-modules.ps1
+++ b/docker-env/scripts/check-installed-modules.ps1
@@ -3,7 +3,7 @@ Param(
     $ApiUrl,
     $Username = "admin",
     $Password = "store",
-    $ContainerId = "virtocommerce_vc-platform-web_1"
+    $ContainerId = "virtocommerce-vc-platform-web-1"
 )
 
 . "./scripts/watch-url-up.ps1"

--- a/docker-env/scripts/inspect-docker-status.ps1
+++ b/docker-env/scripts/inspect-docker-status.ps1
@@ -34,4 +34,3 @@ function InspectContainerStatus {
 
     } until ($status -eq "running" -or $maxRepeat -lt $attempt)
 }
-

--- a/docker-env/scripts/inspect-docker-status.ps1
+++ b/docker-env/scripts/inspect-docker-status.ps1
@@ -1,5 +1,5 @@
 param (
-        [string]$ContainerId = "virtocommerce_vc-platform-web_1",
+        [string]$ContainerId,# = "virtocommerce_vc-platform-web_1",
         [int]$TimeoutMinutes = 5,                  # Max period of time for retry attempts in minutes
         [int]$RetrySeconds = 15,                   # Period of time between retry attempts in seconds
         [int]$WaitSeconds = 0                      # Period of time before start retry attempts in seconds

--- a/docker-env/scripts/inspect-docker-status.ps1
+++ b/docker-env/scripts/inspect-docker-status.ps1
@@ -1,5 +1,5 @@
 param (
-        [string]$ContainerId,# = "virtocommerce_vc-platform-web_1",
+        [string]$ContainerId,# = "virtocommerce-vc-platform-web-1",
         [int]$TimeoutMinutes = 5,                  # Max period of time for retry attempts in minutes
         [int]$RetrySeconds = 15,                   # Period of time between retry attempts in seconds
         [int]$WaitSeconds = 0                      # Period of time before start retry attempts in seconds

--- a/docker-env/scripts/inspect-docker-status.ps1
+++ b/docker-env/scripts/inspect-docker-status.ps1
@@ -1,11 +1,18 @@
+param (
+        [string]$ContainerId = "virtocommerce_vc-platform-web_1",
+        [int]$TimeoutMinutes = 5,                  # Max period of time for retry attempts in minutes
+        [int]$RetrySeconds = 15,                   # Period of time between retry attempts in seconds
+        [int]$WaitSeconds = 0                      # Period of time before start retry attempts in seconds
+    )
+
 Set-Variable -Name "TERM" -Value "xterm-color"
 
 function InspectContainerStatus {
     param (
-        $ContainerId = "virtocommerce_vc-platform-web_1",
-        [int]$TimeoutMinutes = 5,                  # Max period of time for retry attempts in minutes
-        [int]$RetrySeconds = 15,                   # Period of time between retry attempts in seconds
-        [int]$WaitSeconds = 0                      # Period of time before start retry attempts in seconds
+        [string]$ContainerId,
+        [int]$TimeoutMinutes,
+        [int]$RetrySeconds,
+        [int]$WaitSeconds
     )
 
     [int]$maxRepeat = $TimeoutMinutes * 60 / $RetrySeconds

--- a/docker-env/scripts/watch-url-up.ps1
+++ b/docker-env/scripts/watch-url-up.ps1
@@ -6,7 +6,7 @@ function Watch-Url-Up {
         [int]$TimeoutMinutes = 15, # Max period of time for retry attempts in minutes
         [int]$RetrySeconds = 15, # Period of time between retry attempts in seconds
         [int]$WaitSeconds = 60, # Period of time before start retry attempts in seconds
-        [string]$ContainerId = "virtocommerce_vc-platform-web_1" # $ContainerId to write host container log on each 3 unsuccess attempt
+        [string]$ContainerId = "virtocommerce-vc-platform-web-1" # $ContainerId to write host container log on each 3 unsuccess attempt
     )
 
 

--- a/docker-install-modules/README.md
+++ b/docker-install-modules/README.md
@@ -43,6 +43,6 @@ Installs modules to a docker container
     githubToken: ${{ secrets.REPO_TOKEN }}
     manifestUrl: 'https://raw.githubusercontent.com/VirtoCommerce/vc-webstore-deploy/qa/webstore-app/resources/deployment-cm.yaml'
     manifestFormat: 'yml'
-    containerName: 'virtocommerce_vc-platform-web_1'
+    containerName: 'virtocommerce-vc-platform-web-1'
     containerDestination: '/opt/virtocommerce/platform/modules'
 ```

--- a/docker-install-theme/README.md
+++ b/docker-install-theme/README.md
@@ -24,7 +24,7 @@ Installs a theme to docker container
   uses: VirtoCommerce/vc-github-actions/docker-install-theme@master
   with:
     artifactPath: ${{ steps.build.outputs.artifactPath }}
-    containerName: 'virtocommerce_vc-storefront-web_1'
+    containerName: 'virtocommerce-vc-storefront-web-1'
     containerDestination: '/opt/virtocommerce/storefront/wwwroot/cms-content/Themes/B2B-store/default'
     restartContainer: 'true'
 ```


### PR DESCRIPTION
Replace `docker-compose` with `docker compose`.
Fix for containers' names according to the [documentation](https://docs.docker.com/compose/migrate/#service-container-names).
General article for [migrating to compose v2](https://docs.docker.com/compose/migrate/).
