### PR TITLE
Use latest sql server image

### DIFF
--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -52,24 +52,6 @@ services:
       - virto
     restart: unless-stopped
 
-  vc-storefront-web:
-    image: ${STOREFRONT_IMAGE:-virtocommerce/storefront}:${STOREFRONT_DOCKER_TAG:-latest}
-    ports:
-      - "${DOCKER_STOREFRONT_PORT:-8080}:80"
-    env_file:
-      - ${ENV_DIR:-.}/.docker/storefront.env
-    environment:
-      - VirtoCommerce:Endpoint:Url=http://vc-platform-web
-      - VirtoCommerce:Endpoint:UserName=admin
-      - VirtoCommerce:Endpoint:Password=store
-      - ASPNETCORE_ENVIRONMENT=Development 
-    depends_on:
-      - vc-platform-web
-    volumes:
-      - cms-content-volume:/opt/virtocommerce/storefront/wwwroot/cms-content
-    networks:
-      - virto
-
 volumes:
   cms-content-volume:
     name: cms-content-data

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -17,7 +17,7 @@ version: '3.7'
 services:
 
   vc-db:
-    image: mcr.microsoft.com/mssql/server:2017-latest
+    image: mcr.microsoft.com/mssql/server:latest
     ports:
       - "${DOCKER_SQL_PORT:-1433}:1433"
     expose:  

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -12,7 +12,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-version: '3.7'
 
 services:
 


### PR DESCRIPTION
The use of the `2017-latest` SQL server image tag caused the test step to fail, fixed by using the `latest` tag, also removed the storefront and an obsolete `version` parameter from the docker-compose file.