### PR TITLE
Vcst-3944: Add an action to set a custom field for Jira tasks

### DIFF
--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -42,7 +42,7 @@ runs:
       run: |
         $ErrorActionPreference = "Stop"
         $jiraKeys = @()
-        $owner, $repo = ${{ inputs.ghRepository }} -split "/"
+        $owner, $repo = "${{ inputs.ghRepository }}" -split "/"
 
         # Get two latest releases
         $releases = gh api "/repos/$owner/$repo/releases" | ConvertFrom-Json

--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -82,7 +82,7 @@ runs:
         }
         $updateBody = @{
             fields = @{
-                ${{ inputs.jiraCustomFieldId }} = ${{ inputs.jiraCustomFieldValue }}
+                "${{ inputs.jiraCustomFieldId }}" = "${{ inputs.jiraCustomFieldValue }}"
             }
         } | ConvertTo-Json -Depth 5
 

--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Process Jira keys
       shell: pwsh
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         JIRA_USER: ${{ inputs.client-id }}
         JIRA_TOKEN: ${{ inputs.client-secret }}
       run: |

--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -1,0 +1,86 @@
+name: 'Update Jira keys for release'
+description: 'Update Jira keys for release'
+inputs:
+  ghRepository:
+    description: 'GitHub repository in format org/repo'
+    required: true
+    type: string
+  jiraBaseUrl:
+    description: 'Jira base URL'
+    default: 'https://virtocommerce.atlassian.net'
+    required: true
+    type: string
+  jiraCustomFieldId:
+    description: 'Jira custom field ID to update'
+    required: true
+    type: string
+  jiraCustomFieldValue:
+    description: 'Jira custom field value to set'
+    required: true
+    type: string
+# outputs:
+#   jira-keys:
+#     description: 'Jira keys that were found in branch names between previous and last release in comma delimited format'
+  
+runs:
+  using: "composite"
+  steps:       
+    - name: Process Jira keys
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JIRA_USER: ${{ secrets.JIRA_USER }}
+        JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $jiraKeys = @()
+        $owner, $repo = ${{ inputs.ghRepository }} -split "/"
+
+        # Get two latest releases
+        $releases = gh api "/repos/$owner/$repo/releases" | ConvertFrom-Json
+        $releases = $releases | Sort-Object { [datetime]$_.created_at } -Descending
+        $currentTag = $releases[0].tag_name
+        $prevTag = $releases[1].tag_name
+        Write-Host "Comparing $prevTag...$currentTag"
+
+        # Get commits between tags
+        $commits = gh api "/repos/$owner/$repo/compare/$prevTag...$currentTag" --jq ".commits[].sha"
+        
+        foreach ($sha in $commits) {
+            $prs = gh api "/repos/$owner/$repo/commits/$sha/pulls" -H "Accept: application/vnd.github.groot-preview+json" | ConvertFrom-Json
+            foreach ($pr in $prs) {
+                if ($null -ne $pr.head.ref) {
+                    if ($pr.head.ref -match '([A-Z]+-\d{1,6})') {
+                        $jiraKeys += $matches[1]
+                    }
+                    else {
+                        Write-Warning "Branch $($pr.head.ref) does not match the pattern [A-Z]+-\d{1,6}"
+                    }
+                }
+            }
+        }
+        
+        $uniqueJiraKeys = $jiraKeys | Sort-Object -Unique
+        Write-Host "Jira keys merged since last release:"
+        $uniqueJiraKeys | ForEach-Object { Write-Host $_ }
+        # $jiraKeysOutput = $uniqueJiraKeys -join ','
+        # Write-Host "jira-keys=$jiraKeysOutput" >> $GITHUB_OUTPUT
+
+        # Create Jira auth header
+        $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${env:JIRA_USER}:${env:JIRA_TOKEN}"))
+        $headers = @{
+            "Authorization" = "Basic $base64AuthInfo"
+            "Content-Type"  = "application/json"
+        }
+        $updateBody = @{
+            fields = @{
+                ${{ inputs.jiraCustomFieldId }} = ${{ inputs.jiraCustomFieldValue }}
+            }
+        } | ConvertTo-Json -Depth 5
+
+        $uniqueJiraKeys = 'VCST-2609'
+        foreach ($jiraKey in $uniqueJiraKeys) {
+            Write-Host "Updating $jiraKey"
+            $response = Invoke-RestMethod -Uri "${{ inputs.jiraBaseUrl }}/rest/api/3/issue/$jiraKey" -Headers $headers -Method Put -Body $updateBody
+            Write-Host "Updated $jiraKey"
+        }

--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -1,6 +1,14 @@
 name: 'Update Jira keys for release'
 description: 'Update Jira keys for release'
 inputs:
+  client-id:
+    description: 'Client ID'
+    required: true
+    type: string
+  client-secret:
+    description: 'Client secret'
+    required: true
+    type: string
   ghRepository:
     description: 'GitHub repository in format org/repo'
     required: true
@@ -29,8 +37,8 @@ runs:
       shell: pwsh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        JIRA_USER: ${{ secrets.JIRA_USER }}
-        JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+        JIRA_USER: ${{ inputs.client-id }}
+        JIRA_TOKEN: ${{ inputs.client-secret }}
       run: |
         $ErrorActionPreference = "Stop"
         $jiraKeys = @()

--- a/update-jira-keys-release/action.yml
+++ b/update-jira-keys-release/action.yml
@@ -78,7 +78,7 @@ runs:
             }
         } | ConvertTo-Json -Depth 5
 
-        $uniqueJiraKeys = 'VCST-2609'
+        $uniqueJiraKeys = @('VCST-2609')
         foreach ($jiraKey in $uniqueJiraKeys) {
             Write-Host "Updating $jiraKey"
             $response = Invoke-RestMethod -Uri "${{ inputs.jiraBaseUrl }}/rest/api/3/issue/$jiraKey" -Headers $headers -Method Put -Body $updateBody

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -86,9 +86,13 @@ runs:
             }
         } | ConvertTo-Json -Depth 5
 
-        $uniqueJiraKeys = @('VCST-2609')
+        $uniqueJiraKeys = @('VCST-00260900', 'VCST-2609')
         foreach ($jiraKey in $uniqueJiraKeys) {
-            Write-Host "Updating $jiraKey"
-            $response = Invoke-RestMethod -Uri "${{ inputs.jiraBaseUrl }}/rest/api/3/issue/$jiraKey" -Headers $headers -Method Put -Body $updateBody
-            Write-Host "Updated $jiraKey"
+            try {
+              $response = Invoke-RestMethod -Uri "${{ inputs.jiraBaseUrl }}/rest/api/3/issue/$jiraKey" -Headers $headers -Method Put -Body $updateBody
+              Write-Host "✅ Updated task $jiraKey"
+            }
+            catch {
+              Write-Host "❌ Failed to update task $jiraKey. $_.Exception.Message"
+            }
         }

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -93,6 +93,6 @@ runs:
               Write-Host "✅ Updated task $jiraKey"
             }
             catch {
-              Write-Host "❌ Failed to update task $jiraKey. $_.Exception.Message"
+              Write-Host "❌ Failed to update task $jiraKey. $_"
             }
         }

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -26,9 +26,6 @@ inputs:
     description: 'Jira custom field value to set'
     required: true
     type: string
-# outputs:
-#   jira-keys:
-#     description: 'Jira keys that were found in branch names between previous and last release in comma delimited format'
   
 runs:
   using: "composite"
@@ -36,7 +33,6 @@ runs:
     - name: Process Jira keys
       shell: pwsh
       env:
-        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         JIRA_USER: ${{ inputs.client-id }}
         JIRA_TOKEN: ${{ inputs.client-secret }}
       run: |
@@ -71,8 +67,6 @@ runs:
         $uniqueJiraKeys = $jiraKeys | Sort-Object -Unique
         Write-Host "Jira keys merged since last release:"
         $uniqueJiraKeys | ForEach-Object { Write-Host $_ }
-        # $jiraKeysOutput = $uniqueJiraKeys -join ','
-        # Write-Host "jira-keys=$jiraKeysOutput" >> $GITHUB_OUTPUT
 
         # Create Jira auth header
         $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${env:JIRA_USER}:${env:JIRA_TOKEN}"))
@@ -86,7 +80,6 @@ runs:
             }
         } | ConvertTo-Json -Depth 5
 
-        $uniqueJiraKeys = @('VCST-00260900', 'VCST-2609')
         Write-Host "🔄 Updating tasks ..."
         foreach ($jiraKey in $uniqueJiraKeys) {
             try {

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -97,3 +97,4 @@ runs:
               Write-Host "❌ Failed to update task $jiraKey. $($_ -replace '\s+', ' ')"
             }
         }
+        Write-Host "🎉 Done updating tasks"

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -87,12 +87,13 @@ runs:
         } | ConvertTo-Json -Depth 5
 
         $uniqueJiraKeys = @('VCST-00260900', 'VCST-2609')
+        Write-Host "🔄 Updating tasks ..."
         foreach ($jiraKey in $uniqueJiraKeys) {
             try {
               $response = Invoke-RestMethod -Uri "${{ inputs.jiraBaseUrl }}/rest/api/3/issue/$jiraKey" -Headers $headers -Method Put -Body $updateBody
               Write-Host "✅ Updated task $jiraKey"
             }
             catch {
-              Write-Host "❌ Failed to update task $jiraKey. $_"
+              Write-Host "❌ Failed to update task $jiraKey. $($_ -replace '\s+', ' ')"
             }
         }

--- a/update-jira-tasks-with-release-number/action.yml
+++ b/update-jira-tasks-with-release-number/action.yml
@@ -55,17 +55,17 @@ runs:
         $commits = gh api "/repos/$owner/$repo/compare/$prevTag...$currentTag" --jq ".commits[].sha"
         
         foreach ($sha in $commits) {
-            $prs = gh api "/repos/$owner/$repo/commits/$sha/pulls" -H "Accept: application/vnd.github.groot-preview+json" | ConvertFrom-Json
-            foreach ($pr in $prs) {
-                if ($null -ne $pr.head.ref) {
-                    if ($pr.head.ref -match '([A-Z]+-\d{1,6})') {
-                        $jiraKeys += $matches[1]
-                    }
-                    else {
-                        Write-Warning "Branch $($pr.head.ref) does not match the pattern [A-Z]+-\d{1,6}"
-                    }
-                }
-            }
+          $prs = gh api "/repos/$owner/$repo/commits/$sha/pulls" -H "Accept: application/vnd.github.groot-preview+json" | ConvertFrom-Json
+          foreach ($pr in $prs) {
+              if ($null -ne $pr.head.ref) {
+                  if ($pr.head.ref -match '([A-Z]+-\d{1,6})') {
+                      $jiraKeys += $matches[1]
+                  }
+                  else {
+                      Write-Warning "Branch $($pr.head.ref) does not match the pattern [A-Z]+-\d{1,6}"
+                  }
+              }
+          }
         }
         
         $uniqueJiraKeys = $jiraKeys | Sort-Object -Unique


### PR DESCRIPTION
The action updates JIRA tasks with release information by:
1. Getting the two latest releases from the GitHub repository
2. Finding all commits between these releases
3. Extracting JIRA keys from branch names (format: [A-Z]+-\d{1,6})
4. Updating each JIRA task's custom field with the specified value
5. Handling errors gracefully and logging results

Update log example:
<img width="1015" height="97" alt="image" src="https://github.com/user-attachments/assets/fa9d3be8-564f-441e-aeae-c0b16bb41df2" />
