### PR TITLE
VCST-4770: Update actions to use Node 24

### DIFF
--- a/add-version-suffix/action.yml
+++ b/add-version-suffix/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/add-version-suffix/action.yml
+++ b/add-version-suffix/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -15,5 +15,5 @@ outputs:
   imageName: 
     description: "Name of Docker Image"
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -15,5 +15,5 @@ outputs:
   imageName: 
     description: "Name of Docker Image"
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/build-theme/action.yml
+++ b/build-theme/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/build-theme/action.yml
+++ b/build-theme/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/build-vue-theme/action.yml
+++ b/build-vue-theme/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/build-vue-theme/action.yml
+++ b/build-vue-theme/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/cache-get-key/action.yml
+++ b/cache-get-key/action.yml
@@ -25,5 +25,5 @@ outputs:
 
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/cache-get-key/action.yml
+++ b/cache-get-key/action.yml
@@ -25,5 +25,5 @@ outputs:
 
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/changelog-generator/action.yml
+++ b/changelog-generator/action.yml
@@ -4,5 +4,5 @@ outputs:
   changelog:
     description: 'Result'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/changelog-generator/action.yml
+++ b/changelog-generator/action.yml
@@ -4,5 +4,5 @@ outputs:
   changelog:
     description: 'Result'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/check-pr-regression-label/action.yml
+++ b/check-pr-regression-label/action.yml
@@ -21,5 +21,5 @@ outputs:
 
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/check-pr-regression-label/action.yml
+++ b/check-pr-regression-label/action.yml
@@ -21,5 +21,5 @@ outputs:
 
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/cloud-create-deploy-matrix/action.yml
+++ b/cloud-create-deploy-matrix/action.yml
@@ -13,5 +13,5 @@ outputs:
     description: 'Matrix of deployment environments'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/cloud-create-deploy-matrix/action.yml
+++ b/cloud-create-deploy-matrix/action.yml
@@ -13,5 +13,5 @@ outputs:
     description: 'Matrix of deployment environments'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/cloud-create-deployment/action.yml
+++ b/cloud-create-deployment/action.yml
@@ -61,5 +61,5 @@ inputs:
     default: "true"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/cloud-create-deployment/action.yml
+++ b/cloud-create-deployment/action.yml
@@ -61,5 +61,5 @@ inputs:
     default: "true"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/cloud-get-deploy-param/action.yml
+++ b/cloud-get-deploy-param/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: 'Full deploy config(for all environments)'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/cloud-get-deploy-param/action.yml
+++ b/cloud-get-deploy-param/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: 'Full deploy config(for all environments)'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/create-deploy-pr/action.yml
+++ b/create-deploy-pr/action.yml
@@ -43,5 +43,5 @@ inputs:
     default: "false"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/create-deploy-pr/action.yml
+++ b/create-deploy-pr/action.yml
@@ -43,5 +43,5 @@ inputs:
     default: "false"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-check-modules/action.yml
+++ b/docker-check-modules/action.yml
@@ -15,5 +15,5 @@ inputs:
     default: 'store'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-check-modules/action.yml
+++ b/docker-check-modules/action.yml
@@ -15,5 +15,5 @@ inputs:
     default: 'store'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-install-modules/action.yml
+++ b/docker-install-modules/action.yml
@@ -32,5 +32,5 @@ inputs:
     required: false
     default: 'VirtoCommerce'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-install-modules/action.yml
+++ b/docker-install-modules/action.yml
@@ -32,5 +32,5 @@ inputs:
     required: false
     default: 'VirtoCommerce'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-install-sampledata/action.yml
+++ b/docker-install-sampledata/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'store'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-install-sampledata/action.yml
+++ b/docker-install-sampledata/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'store'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-install-theme/action.yml
+++ b/docker-install-theme/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-install-theme/action.yml
+++ b/docker-install-theme/action.yml
@@ -15,5 +15,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-load-image/action.yml
+++ b/docker-load-image/action.yml
@@ -12,5 +12,5 @@ outputs:
     description: 'Published image tag'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-load-image/action.yml
+++ b/docker-load-image/action.yml
@@ -12,5 +12,5 @@ outputs:
     description: 'Published image tag'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-restore-dump/action.yml
+++ b/docker-restore-dump/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'Dump file url'
     required: true 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/docker-restore-dump/action.yml
+++ b/docker-restore-dump/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'Dump file url'
     required: true 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/docker-start-environment/action.yml
+++ b/docker-start-environment/action.yml
@@ -21,5 +21,5 @@ inputs:
     default: 'virtocommerce'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-start-environment/action.yml
+++ b/docker-start-environment/action.yml
@@ -21,5 +21,5 @@ inputs:
     default: 'virtocommerce'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/docker-validate-swagger/action.yml
+++ b/docker-validate-swagger/action.yml
@@ -15,5 +15,5 @@ inputs:
     default: 'https://validator.swagger.io/validator/debug'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/docker-validate-swagger/action.yml
+++ b/docker-validate-swagger/action.yml
@@ -15,5 +15,5 @@ inputs:
     default: 'https://validator.swagger.io/validator/debug'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/generate-dashboard-durations/action.yml
+++ b/generate-dashboard-durations/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: "Path to the result file"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/generate-dashboard-durations/action.yml
+++ b/generate-dashboard-durations/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: "Path to the result file"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/generate-dashboard/action.yml
+++ b/generate-dashboard/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: "Path to the result file"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/generate-dashboard/action.yml
+++ b/generate-dashboard/action.yml
@@ -17,5 +17,5 @@ outputs:
     description: "Path to the result file"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/get-artifact-link/action.yml
+++ b/get-artifact-link/action.yml
@@ -22,5 +22,5 @@ outputs:
     description: "Jira task number to create deploy PR in Demo environment"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/get-artifact-link/action.yml
+++ b/get-artifact-link/action.yml
@@ -22,5 +22,5 @@ outputs:
     description: "Jira task number to create deploy PR in Demo environment"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/get-deploy-param/action.yml
+++ b/get-deploy-param/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: 'Full deploy config(for all environments)'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/get-deploy-param/action.yml
+++ b/get-deploy-param/action.yml
@@ -35,5 +35,5 @@ outputs:
     description: 'Full deploy config(for all environments)'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/get-image-version/action.yml
+++ b/get-image-version/action.yml
@@ -44,5 +44,5 @@ outputs:
 
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/get-image-version/action.yml
+++ b/get-image-version/action.yml
@@ -44,5 +44,5 @@ outputs:
 
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/get-jira-keys/action.yml
+++ b/get-jira-keys/action.yml
@@ -13,5 +13,5 @@ outputs:
   jira-keys:
     description: 'Jira keys that were found in push/pull request in comma delimited format'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/get-jira-keys/action.yml
+++ b/get-jira-keys/action.yml
@@ -13,5 +13,5 @@ outputs:
   jira-keys:
     description: 'Jira keys that were found in push/pull request in comma delimited format'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/gh-deployments/action.yml
+++ b/gh-deployments/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: bookmark
   color: yellow
 runs:
-  using: node20
+  using: 'node22'
   main: dist/index.js
 
 inputs:

--- a/gh-deployments/action.yml
+++ b/gh-deployments/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: bookmark
   color: yellow
 runs:
-  using: 'node22'
+  using: 'node24'
   main: dist/index.js
 
 inputs:

--- a/katalon-studio-github-action/action.yml
+++ b/katalon-studio-github-action/action.yml
@@ -22,5 +22,5 @@ inputs:
             default: '-a -n 99 -s "-screen 99 1920x1080x24"'
 
 runs:
-      using: 'node22'
+      using: 'node24'
       main: 'index.js'

--- a/katalon-studio-github-action/action.yml
+++ b/katalon-studio-github-action/action.yml
@@ -22,5 +22,5 @@ inputs:
             default: '-a -n 99 -s "-screen 99 1920x1080x24"'
 
 runs:
-      using: 'node20'
+      using: 'node22'
       main: 'index.js'

--- a/msteams-send-message/action.yml
+++ b/msteams-send-message/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/msteams-send-message/action.yml
+++ b/msteams-send-message/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/pr-body-get-link/action.yml
+++ b/pr-body-get-link/action.yml
@@ -26,5 +26,5 @@ outputs:
     description: "Jira task number to create deploy PR in Demo environment"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/pr-body-get-link/action.yml
+++ b/pr-body-get-link/action.yml
@@ -26,5 +26,5 @@ outputs:
     description: "Jira task number to create deploy PR in Demo environment"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/publish-artifact-link/action.yml
+++ b/publish-artifact-link/action.yml
@@ -17,5 +17,5 @@ inputs:
     default: "Download artifact URL:"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/publish-artifact-link/action.yml
+++ b/publish-artifact-link/action.yml
@@ -17,5 +17,5 @@ inputs:
     default: "Download artifact URL:"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/publish-blob-release/action.yml
+++ b/publish-blob-release/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "Blob id"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/publish-blob-release/action.yml
+++ b/publish-blob-release/action.yml
@@ -15,5 +15,5 @@ outputs:
     description: "Blob id"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/publish-docker-image/action.yml
+++ b/publish-docker-image/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: true
     default: "true"
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/publish-docker-image/action.yml
+++ b/publish-docker-image/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: true
     default: "true"
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/publish-github-release/action.yml
+++ b/publish-github-release/action.yml
@@ -27,5 +27,5 @@ outputs:
     description: "GitHub release download URL"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/publish-github-release/action.yml
+++ b/publish-github-release/action.yml
@@ -27,5 +27,5 @@ outputs:
     description: "GitHub release download URL"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/publish-jira-link/action.yml
+++ b/publish-jira-link/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: false
     default: "Jira-link:"
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/publish-jira-link/action.yml
+++ b/publish-jira-link/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: false
     default: "Jira-link:"
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/publish-katalon-report/action.yml
+++ b/publish-katalon-report/action.yml
@@ -22,5 +22,5 @@ inputs:
     default: "false"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/publish-katalon-report/action.yml
+++ b/publish-katalon-report/action.yml
@@ -22,5 +22,5 @@ inputs:
     default: "false"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/publish-manifest/action.yml
+++ b/publish-manifest/action.yml
@@ -25,5 +25,5 @@ outputs:
   modulesJsonPath:
     description: "Path to updated modules.json"
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/publish-manifest/action.yml
+++ b/publish-manifest/action.yml
@@ -25,5 +25,5 @@ outputs:
   modulesJsonPath:
     description: "Path to updated modules.json"
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: "Clean+Restore+Compile+Test"
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/publish-nuget/action.yml
+++ b/publish-nuget/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: "Clean+Restore+Compile+Test"
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/publish-theme/action.yml
+++ b/publish-theme/action.yml
@@ -24,5 +24,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/publish-theme/action.yml
+++ b/publish-theme/action.yml
@@ -24,5 +24,5 @@ outputs:
     description: 'Name of artifact'
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/run-e2e-tests/action.yml
+++ b/run-e2e-tests/action.yml
@@ -41,12 +41,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
     - name: Getting tests
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.vctestingRepo }}
         ref: ${{ inputs.vctestingRepoBranch }}
@@ -103,7 +103,7 @@ runs:
 
     - name: Upload dataset_manager log
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: e2e-dataset-manager-log-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: ${{ inputs.vctestingPath }}/dataset/dataset_manager.log
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: e2e-test-results-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: |

--- a/run-graphql-tests/action.yml
+++ b/run-graphql-tests/action.yml
@@ -41,12 +41,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
     - name: Getting tests
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.vctestingRepo }}
         ref: ${{ inputs.vctestingRepoBranch }}
@@ -103,7 +103,7 @@ runs:
 
     - name: Upload dataset_manager log
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: graphql-dataset-manager-log-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: ${{ inputs.vctestingPath }}/dataset/dataset_manager.log
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: graphql-test-results-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: |

--- a/set-version-up/action.yml
+++ b/set-version-up/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
     default: 'minor'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/set-version-up/action.yml
+++ b/set-version-up/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
     default: 'minor'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/setup-git-credentials-github/action.yml
+++ b/setup-git-credentials-github/action.yml
@@ -13,5 +13,5 @@ inputs:
     description: "GitHub Token"
     required: false
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/setup-git-credentials-github/action.yml
+++ b/setup-git-credentials-github/action.yml
@@ -13,5 +13,5 @@ inputs:
     description: "GitHub Token"
     required: false
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/setup-vcbuild/action.yml
+++ b/setup-vcbuild/action.yml
@@ -1,5 +1,5 @@
 name: 'setup-vcbuild'
 description: 'Setups vc-build'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/setup-vcbuild/action.yml
+++ b/setup-vcbuild/action.yml
@@ -1,5 +1,5 @@
 name: 'setup-vcbuild'
 description: 'Setups vc-build'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/sonar-quality-gate/action.yml
+++ b/sonar-quality-gate/action.yml
@@ -17,5 +17,5 @@ inputs:
       default: ""
       required: false
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/sonar-quality-gate/action.yml
+++ b/sonar-quality-gate/action.yml
@@ -17,5 +17,5 @@ inputs:
       default: ""
       required: false
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/sonar-scanner-begin/action.yml
+++ b/sonar-scanner-begin/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: "virto-commerce"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/sonar-scanner-begin/action.yml
+++ b/sonar-scanner-begin/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: "virto-commerce"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/sonar-scanner-end/action.yml
+++ b/sonar-scanner-end/action.yml
@@ -1,5 +1,5 @@
 name: 'sonar-scanner-end'
 description: 'Runs vc-build SonarQubeEnd'
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/sonar-scanner-end/action.yml
+++ b/sonar-scanner-end/action.yml
@@ -1,5 +1,5 @@
 name: 'sonar-scanner-end'
 description: 'Runs vc-build SonarQubeEnd'
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/sonar-theme/action.yml
+++ b/sonar-theme/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: "Target branch name for sonar branch analysis"
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'index.js'

--- a/sonar-theme/action.yml
+++ b/sonar-theme/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: "Target branch name for sonar branch analysis"
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'index.js'

--- a/update-deploy-config/action.yml
+++ b/update-deploy-config/action.yml
@@ -62,5 +62,5 @@ inputs:
 
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/update-deploy-config/action.yml
+++ b/update-deploy-config/action.yml
@@ -62,5 +62,5 @@ inputs:
 
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/update-virtocommerce-docs-versioned/action.yml
+++ b/update-virtocommerce-docs-versioned/action.yml
@@ -73,7 +73,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout vc-docs repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         repository: VirtoCommerce/vc-docs
         ref: main
@@ -83,7 +83,7 @@ runs:
         persist-credentials: true
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 

--- a/update-virtocommercecom/action.yml
+++ b/update-virtocommercecom/action.yml
@@ -38,5 +38,5 @@ inputs:
     default: ""
     required: false
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/update-virtocommercecom/action.yml
+++ b/update-virtocommercecom/action.yml
@@ -38,5 +38,5 @@ inputs:
     default: ""
     required: false
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'

--- a/update-webhook-configuration/action.yml
+++ b/update-webhook-configuration/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js' 

--- a/update-webhook-configuration/action.yml
+++ b/update-webhook-configuration/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js' 

--- a/validate-swagger/action.yml
+++ b/validate-swagger/action.yml
@@ -11,5 +11,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node22'
   main: 'dist/index.js'

--- a/validate-swagger/action.yml
+++ b/validate-swagger/action.yml
@@ -11,5 +11,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node22'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly mechanical CI action version bumps, but moving many custom JavaScript actions from `node20` to `node24` could surface runtime/dependency incompatibilities in workflows.
> 
> **Overview**
> Upgrades the repository’s custom JavaScript GitHub Actions to run on **Node 24** (from `node20`) by updating the `runs.using` field across the action definitions.
> 
> Also refreshes several composite actions to newer upstream action versions, notably bumping `actions/checkout`, `actions/setup-python`, and `actions/upload-artifact` to their latest major releases in the E2E/GraphQL test runners and versioned docs deploy workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b77745f2850d72fefb6070cff0988420d55369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->