### PR TITLE
Remove unused Azure inputs from docs versioning action

### DIFF
--- a/update-virtocommerce-docs-versioned/action.yml
+++ b/update-virtocommerce-docs-versioned/action.yml
@@ -20,24 +20,6 @@ inputs:
     description: "Set this version as default version"
     required: false
     default: "true"
-  azureSubscriptionId:
-    description: "Azure Subscription ID"
-    required: true
-  azureResourceGroupName:
-    description: "Azure Resource Group Name"
-    required: true
-  azureWebAppName:
-    description: "Azure WebApp Name"
-    required: true
-  azureTenantId:
-    description: "Azure Tenant ID"
-    required: true
-  azureApiKey:
-    description: "Azure API Key"
-    required: true
-  azureAppId:
-    description: "Azure App ID"
-    required: true
   dockerRegistry:
     description: "Docker Registry"
     required: true


### PR DESCRIPTION
## Summary

Follow-up to #223. Removes 6 unused Azure inputs from `update-virtocommerce-docs-versioned/action.yml`: `azureSubscriptionId`, `azureResourceGroupName`, `azureWebAppName`, `azureTenantId`, `azureApiKey`, `azureAppId`.

These inputs were declared as `required: true` but never read by any step in the action. Almost certainly legacy from an earlier version that did its own Azure deploy; the logic moved out at some point and the inputs were forgotten.

## Companion cleanup in vc-docs

The corresponding `with:` lines will be removed from `vc-docs/.github/workflows/deploy.yml` in the vc-docs PR (https://github.com/VirtoCommerce/vc-docs/pull/51). Order doesn't matter — extra `with:` inputs to a composite action are silently ignored by GitHub Actions.

## Test plan

- [ ] YAML validates locally.
- [ ] `grep -i azure update-virtocommerce-docs-versioned/action.yml` — no matches.
- [ ] No other workflow or caller in this repo references the removed inputs.