### PR TITLE
VCST-4958: Fix module version update in case it is not in initial packages list

### DIFF
--- a/docker-env/scripts/common-packages-list.ps1
+++ b/docker-env/scripts/common-packages-list.ps1
@@ -186,11 +186,17 @@ function ProcessCustomModule {
 
     if ($recursive -eq $true) {
         foreach ($dependency in $xmlDependency) {
-            if ($script:packages["$($dependency.id)"] -match "\w._(.*).zip") {
-                CompareVersions -currentVersion $Matches[1] -requiredVersion $($dependency.version) -moduleId $($dependency.id)
+            if ($script:packages.Keys -contains $dependency.id) {
+                if ($script:packages["$($dependency.id)"] -match "\w._(.*).zip") {
+                    CompareVersions -currentVersion $Matches[1] -requiredVersion $($dependency.version) -moduleId $($dependency.id)
+                }
+                else {
+                    Write-Warning "Unable to parse version from packages list. Tried '$($script:packages[$dependency.id])' -match '\w._(.*).zip'"
+                }
             }
             else {
-                Write-Warning "Unable to parse version from packages list. Tried $packages[$key] -match '\w._(.*).zip'"
+                $script:packages["$($dependency.id)"] = "$($dependency.id)_$($dependency.version).zip"
+                if (-not $script:packageSources.ContainsKey($dependency.id)) { $script:packageSources["$($dependency.id)"] = "dep:$CustomModuleId" }
             }
             Write-Verbose "Dependency: $($dependency.id) $($dependency.version)"
         }
@@ -311,11 +317,17 @@ ProcessCustomModule -CustomModuleId $customModuleId -CustomModuleUrl $customModu
 # resolve first level dependencies
 foreach ($key in $dependencyList.Keys) {
     # add dep to packages
-    if ($packages["$key"] -match "\w._(.*).zip") {
-        CompareVersions -currentVersion $Matches[1] -requiredVersion $dependencyList["$key"] -moduleId $key
+    if ($packages.Keys -contains $key) {
+        if ($packages["$key"] -match "\w._(.*).zip") {
+            CompareVersions -currentVersion $Matches[1] -requiredVersion $dependencyList["$key"] -moduleId $key
+        }
+        else {
+            Write-Warning "Unable to parse version from packages list. Tried '$($packages[$key])' -match '\w._(.*).zip'"
+        }
     }
     else {
-        Write-Warning "Unable to parse version from packages list. Tried $packages[$key] -match '\w._(.*).zip'"
+        $packages["$key"] = "$($key)_$($dependencyList[$key]).zip"
+        if (-not $packageSources.ContainsKey($key)) { $packageSources["$key"] = "dep:$customModuleId" }
     }
     # get dep2lev
     if ($($dependencyList["$key"].split('.')[2]) -notmatch '[A-za-z-]' -and $packagesProcessed -notcontains $key) {


### PR DESCRIPTION
- (first-level dep loop): If a dep from $dependencyList isn't already in $packages, add it with the declared version (mirroring what the deeper loop at line 377-385 already does). The warning now uses $($packages[$key]) so it shows the actual value, not System.Collections.Hashtable[...].
- (ProcessCustomModule recursive branch): Same fix — add missing deps instead of warning, and the warning string now references $dependency.id (the in-scope variable) rather than the undefined $key.
Example: VirtoCommerce.Pages was being declared as a dependency by your custom module but wasn't pre-loaded (it isn't in the commerce group nor in the required-modules list), so it was being silently dropped from new-packages.json. Now it gets added with dep:<customModuleId> as its source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes module/package manifest generation logic, which can affect which modules/versions are installed in CI or local docker builds. Scope is small and guarded, but incorrect dependency/version parsing could still alter build outcomes.
> 
> **Overview**
> Fixes dependency resolution in `common-packages-list.ps1` so modules declared as dependencies are **added to `$packages` when missing**, instead of being silently skipped.
> 
> This updates both the first-level dependency loop and the recursive `ProcessCustomModule` dependency branch to (1) check key existence before parsing versions, (2) emit a clearer warning when a package filename can’t be parsed, and (3) record new entries with a `dep:<moduleId>` source for traceability in the resolution summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9309548a7e4408bcc1fb27312288fb59e70448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->