### PR TITLE
VCST-5041: Add DB provider selector for docker compose installation

### DIFF
--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -165,6 +165,25 @@ runs:
         docker build -f ./nginx/Dockerfile -t "${{ inputs.frontendImage }}:${{ inputs.frontendDockerTag }}" .
         Write-Host "::endgroup::"
 
+    - name: Generate container secrets
+      shell: pwsh
+      run: |
+        function New-RandomPassword {
+          # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
+          # (upper/lower/digit/symbol) and stay free of connection-string delimiters.
+          $alphabet = [char[]]'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+          $bytes = New-Object byte[] 32
+          [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+          $chars = foreach ($b in $bytes) { $alphabet[$b % $alphabet.Length] }
+          return 'Vc!' + (-join $chars)
+        }
+        $dbPassword = New-RandomPassword
+        $esPassword = New-RandomPassword
+        Write-Host "::add-mask::$dbPassword"
+        Write-Host "::add-mask::$esPassword"
+        Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
+        Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
+
     - name: Start database container only
       env:
         PLATFORM_IMAGE: ${{ inputs.platformImage }}

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: 'Directory with environment files'
     required: false
     default: '.'
+  databaseProvider:
+    description: 'Database provider: sqlserver | mysql | postgres'
+    required: false
+    default: 'sqlserver'
 runs:
   using: "composite"
   steps:
@@ -184,7 +188,7 @@ runs:
         }
         # Start only the database and elasticsearch containers first
         Write-Host "::group::Start Database and Elasticsearch containers"
-        docker compose --project-name virtocommerce up -d vc-db es
+        docker compose --project-name virtocommerce -f docker-compose.yml -f docker-compose.${{ inputs.databaseProvider }}.yml up -d vc-db es
         Write-Host "::endgroup::"
         Write-Host "`e[32mDatabase and Elasticsearch containers started."
 
@@ -203,7 +207,7 @@ runs:
         
         # Start the remaining containers (platform and frontend)
         Write-Host "::group::Start Remaining Containers"
-        docker compose --project-name virtocommerce up -d
+        docker compose --project-name virtocommerce -f docker-compose.yml -f docker-compose.${{ inputs.databaseProvider }}.yml up -d
         Write-Host "::endgroup::"
         InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0
         Write-Host "`e[32mAll containers started."

--- a/docker-env-full/docker-compose.mysql.yml
+++ b/docker-env-full/docker-compose.mysql.yml
@@ -6,7 +6,7 @@ services:
       - "${MYSQL_PORT:-3306}:3306"
     environment:
       - MYSQL_DATABASE=VirtoCommerce3docker
-      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
     volumes:
       - mysql_data:/var/lib/mysql
     networks:
@@ -15,7 +15,7 @@ services:
   vc-platform-web:
     environment:
       - DatabaseProvider=MySql
-      - ConnectionStrings:VirtoCommerce=Server=vc-db;Port=3306;Database=VirtoCommerce3docker;User=root;Password=${DB_PASSWORD:-v!rto_Labs!}
+      - ConnectionStrings:VirtoCommerce=Server=vc-db;Port=3306;Database=VirtoCommerce3docker;User=root;Password=${DB_PASSWORD}
     depends_on:
       - vc-db
       - es

--- a/docker-env-full/docker-compose.mysql.yml
+++ b/docker-env-full/docker-compose.mysql.yml
@@ -1,0 +1,29 @@
+services:
+
+  vc-db:
+    image: mysql:${MYSQL_VERSION:-9.3}
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    environment:
+      - MYSQL_DATABASE=VirtoCommerce3docker
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - virto
+
+  vc-platform-web:
+    environment:
+      - DatabaseProvider=MySql
+      - ConnectionStrings:VirtoCommerce=Server=vc-db;Port=3306;Database=VirtoCommerce3docker;User=root;Password=${DB_PASSWORD:-v!rto_Labs!}
+    depends_on:
+      - vc-db
+      - es
+    entrypoint: ["/wait-for-it.sh", "vc-db:3306", "-t", "120", "--", "/wait-for-it.sh", "es:9200", "-t", "120", "--", "dotnet", "VirtoCommerce.Platform.Web.dll"]
+
+volumes:
+  mysql_data:
+    driver: local
+
+networks:
+  virto:

--- a/docker-env-full/docker-compose.postgres.yml
+++ b/docker-env-full/docker-compose.postgres.yml
@@ -1,0 +1,30 @@
+services:
+
+  vc-db:
+    image: postgres:${PGSQL_VERSION:-18.3}
+    ports:
+      - "${PGSQL_PORT:-5432}:5432"
+    environment:
+      - POSTGRES_DB=VirtoCommerce3docker
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    networks:
+      - virto
+
+  vc-platform-web:
+    environment:
+      - DatabaseProvider=PostgreSql
+      - ConnectionStrings:VirtoCommerce=User ID=postgres;Password=${DB_PASSWORD:-v!rto_Labs!};Host=vc-db;Port=5432;Database=VirtoCommerce3docker
+    depends_on:
+      - vc-db
+      - es
+    entrypoint: ["/wait-for-it.sh", "vc-db:5432", "-t", "120", "--", "/wait-for-it.sh", "es:9200", "-t", "120", "--", "dotnet", "VirtoCommerce.Platform.Web.dll"]
+
+volumes:
+  postgres_data:
+    driver: local
+
+networks:
+  virto:

--- a/docker-env-full/docker-compose.postgres.yml
+++ b/docker-env-full/docker-compose.postgres.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - POSTGRES_DB=VirtoCommerce3docker
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql
     networks:
@@ -16,7 +16,7 @@ services:
   vc-platform-web:
     environment:
       - DatabaseProvider=PostgreSql
-      - ConnectionStrings:VirtoCommerce=User ID=postgres;Password=${DB_PASSWORD:-v!rto_Labs!};Host=vc-db;Port=5432;Database=VirtoCommerce3docker
+      - ConnectionStrings:VirtoCommerce=User ID=postgres;Password=${DB_PASSWORD};Host=vc-db;Port=5432;Database=VirtoCommerce3docker
     depends_on:
       - vc-db
       - es

--- a/docker-env-full/docker-compose.sqlserver.yml
+++ b/docker-env-full/docker-compose.sqlserver.yml
@@ -9,14 +9,14 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - MSSQL_PID=Express
-      - MSSQL_SA_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+      - MSSQL_SA_PASSWORD=${DB_PASSWORD}
     networks:
       - virto
 
   vc-platform-web:
     environment:
       - DatabaseProvider=SqlServer
-      - ConnectionStrings:VirtoCommerce=Data Source=vc-db;Initial Catalog=VirtoCommerce3docker;Persist Security Info=True;User ID=sa;Password=${DB_PASSWORD:-v!rto_Labs!};MultipleActiveResultSets=False;Connect Timeout=360;TrustServerCertificate=True;
+      - ConnectionStrings:VirtoCommerce=Data Source=vc-db;Initial Catalog=VirtoCommerce3docker;Persist Security Info=True;User ID=sa;Password=${DB_PASSWORD};MultipleActiveResultSets=False;Connect Timeout=360;TrustServerCertificate=True;
     depends_on:
       - vc-db
       - es

--- a/docker-env-full/docker-compose.sqlserver.yml
+++ b/docker-env-full/docker-compose.sqlserver.yml
@@ -1,0 +1,26 @@
+services:
+
+  vc-db:
+    image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION:-2022-latest}
+    ports:
+      - "${DOCKER_SQL_PORT:-1433}:1433"
+    expose:
+      - 1433
+    environment:
+      - ACCEPT_EULA=Y
+      - MSSQL_PID=Express
+      - MSSQL_SA_PASSWORD=${DB_PASSWORD:-v!rto_Labs!}
+    networks:
+      - virto
+
+  vc-platform-web:
+    environment:
+      - DatabaseProvider=SqlServer
+      - ConnectionStrings:VirtoCommerce=Data Source=vc-db;Initial Catalog=VirtoCommerce3docker;Persist Security Info=True;User ID=sa;Password=${DB_PASSWORD:-v!rto_Labs!};MultipleActiveResultSets=False;Connect Timeout=360;TrustServerCertificate=True;
+    depends_on:
+      - vc-db
+      - es
+    entrypoint: ["/wait-for-it.sh", "vc-db:1433", "-t", "120", "--", "/wait-for-it.sh", "es:9200", "-t", "120", "--", "dotnet", "VirtoCommerce.Platform.Web.dll"]
+
+networks:
+  virto:

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -13,20 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-services:
+# Base file. The vc-db service and vc-platform-web DB connection settings live
+# in docker-compose.<provider>.yml overlays. Always combine with one overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.sqlserver.yml up -d
 
-  vc-db:
-    image: mcr.microsoft.com/mssql/server:2017-latest
-    ports:
-      - "${DOCKER_SQL_PORT:-1433}:1433"
-    expose:  
-      - 1433  
-    environment: 
-      - ACCEPT_EULA=Y
-      - MSSQL_PID=Express
-      - SA_PASSWORD=v!rto_Labs!
-    networks:
-      - virto
+services:
 
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-8.18.0}
@@ -61,7 +52,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 120
-  
+
   nginx_frontend:
     depends_on:
       - vc-platform-web
@@ -79,7 +70,6 @@ services:
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory
-      - ConnectionStrings:VirtoCommerce=Data Source=vc-db;Initial Catalog=VirtoCommerce3docker;Persist Security Info=True;User ID=sa;Password=v!rto_Labs!;MultipleActiveResultSets=False;Connect Timeout=360;TrustServerCertificate=True;
       - Assets:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/assets/
       - Content:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/cms-content/
       - Search:Provider=ElasticSearch8
@@ -93,9 +83,7 @@ services:
       - Notifications:Gateway=SendGrid
       - Notifications:SendGrid:ApiKey=${SENDGRID_API_KEY}
     depends_on:
-      - vc-db
       - es
-    entrypoint: ["/wait-for-it.sh", "vc-db:1433", "-t", "120", "--", "dotnet", "VirtoCommerce.Platform.Web.dll"]
     volumes:
       - cms-content-volume:/opt/virtocommerce/platform/wwwroot/cms-content
       - modules-volume:/opt/virtocommerce/platform/modules

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - node.name=es
       - cluster.name=${CLUSTER_NAME:-elasticsearch}
       - cluster.initial_master_nodes=es
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-v!rto_Labs!}
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
@@ -75,7 +75,7 @@ services:
       - Search:Provider=ElasticSearch8
       - Search:ElasticSearch8:Server=http://es:${ES_PORT:-9200}
       - Search:ElasticSearch8:User=elastic
-      - Search:ElasticSearch8:Key=${ELASTIC_PASSWORD:-v!rto_Labs!}
+      - Search:ElasticSearch8:Key=${ELASTIC_PASSWORD}
       - Search:ElasticSearch8:EnableCompatibilityMode=true
       - Search:PickupLocationFullTextSearchEnabled=true
       - IdentityOptions:User:MaxPasswordAge=0

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -46,6 +46,11 @@ inputs:
     description: 'UI tests repository branch'
     required: true
     type: string
+  artifactSuffix:
+    description: 'Suffix appended to the uploaded artifact name (e.g., a matrix dimension)'
+    required: false
+    default: ''
+    type: string
 runs:
   using: "composite"
   steps:
@@ -252,7 +257,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: test-results-${{ github.run_number }}-${{ github.run_attempt }}
+        name: test-results-${{ github.run_number }}-${{ github.run_attempt }}${{ inputs.artifactSuffix }}
         path: ${{ inputs.vctestingPath }}/report/
         if-no-files-found: warn
         retention-days: 30


### PR DESCRIPTION
## Summary

Refactor `docker-env-full` to support three database providers (SQL Server, MySQL, PostgreSQL). Pattern from [VirtoCommerce/start-local](https://github.com/VirtoCommerce/start-local/tree/dev): base `docker-compose.yml` + per-provider overlay, combined via `-f base -f overlay`. Adds `artifactSuffix` to `run-pytest-tests` so matrixed callers don't collide on uploads. Replaces hardcoded `v!rto_Labs!` defaults with per-run random passwords.

Companion: VirtoCommerce/.github#<NN> (matrixes `pytest-tests.yml`).

Jira: [VCST-5041](https://virtocommerce.atlassian.net/browse/VCST-5041)

## What changed

- `docker-env-full/docker-compose.yml` (base) — removed `vc-db` service, removed DB-specific config from `vc-platform-web` (`ConnectionStrings`, `entrypoint`, `depends_on: vc-db`), dropped `${ELASTIC_PASSWORD:-v!rto_Labs!}` literal.
- `docker-env-full/docker-compose.{sqlserver,mysql,postgres}.yml` (new) — each defines `vc-db` (image/env/ports) and overlays `vc-platform-web` with the matching `DatabaseProvider`, connection string, and `wait-for-it.sh` entrypoint.
- `docker-env-full/action.yml`:
  - new `databaseProvider` input (`sqlserver` | `mysql` | `postgres`, default `sqlserver`).
  - new step "Generate container secrets" — random `DB_PASSWORD` + `ELASTIC_PASSWORD`, masked via `::add-mask::`, exported via `$GITHUB_ENV`.
  - both `docker compose up` invocations now pass `-f docker-compose.yml -f docker-compose.${{ inputs.databaseProvider }}.yml`.
- `run-pytest-tests/action.yml` — new `artifactSuffix` input (default `''`); appended to uploaded artifact name.

## Behavior changes for existing callers

`e2e-autotests.yml`, `ui-autotests.yml`, `pytest-tests.yml@v3.800.30` need **no input changes** — `databaseProvider` defaults to `sqlserver`. On merge they silently pick up:

- SQL Server image: `mssql/server:2017-latest` → `mssql/server:2022-latest`.
- DB password: hardcoded `v!rto_Labs!` → random per run.
- Elasticsearch password: hardcoded `v!rto_Labs!` → random per run.

Test runners (`run-e2e-tests`, `run-graphql-tests`, `run-pytest-tests`) go through the platform HTTP API, not direct DB, so unaffected. Verify no test code in `vc-testing-module` or similar references the old literal before merge.

## Test plan

- [ ] Companion PR matrix passes all three legs.
- [ ] `module-ci.yml` consumer (e.g. `vc-quote`) auto-tests pass via the SQL Server default path.
- [ ] `grep -rni "v!rto_Labs!" vc-testing-module/` returns no usable hits.

## Known follow-ups (fix-forward if a leg fails)

- MySQL connection string may need `SslMode=Preferred;AllowPublicKeyRetrieval=True` for `caching_sha2_password` (MySQL 9 default).
- `'store'` literal (Virto-seeded admin password) still in `scripts/*.ps1` and `action.yml` — not a real secret; fixing requires a different bootstrap flow.
- `RandomNumberGenerator::Create()` not disposed — process is short-lived; cosmetic.


[VCST-5041]: https://virtocommerce.atlassian.net/browse/VCST-5041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker-based test environment startup (compose topology, DB images, and secrets), so misconfiguration could break CI runs across different database providers.
> 
> **Overview**
> Refactors `docker-env-full` Docker Compose setup to support **selectable database providers** via overlays (`docker-compose.sqlserver.yml`, `.mysql.yml`, `.postgres.yml`) and a new `databaseProvider` input, with the composite action now bringing containers up using `-f docker-compose.yml -f docker-compose.<provider>.yml`.
> 
> Removes hardcoded DB/Elasticsearch passwords from compose and adds a step to **generate and mask per-run `DB_PASSWORD`/`ELASTIC_PASSWORD`** exported through `$GITHUB_ENV`.
> 
> Updates `run-pytest-tests` to accept an optional `artifactSuffix` and append it to the uploaded `test-results-*` artifact name to avoid collisions in matrix runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c0d2519118bdfaa3073c6061bb6c793f462e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->