### PR TITLE
VCST-5098: Add authorization header for api.github.com calls

### DIFF
--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -138,9 +138,16 @@ runs:
     - name: Build frontend docker image
       working-directory: ${{ github.action_path }}
       shell: pwsh
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         if ( "${{ inputs.frontendZipUrl }}" -eq 'latest' ) {
-          $frontendReleaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/VirtoCommerce/vc-frontend/releases/latest"
+          $headers = @{
+            Authorization          = "Bearer $env:GH_TOKEN"
+            Accept                 = 'application/vnd.github+json'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+          $frontendReleaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/VirtoCommerce/vc-frontend/releases/latest" -Headers $headers
           $frontendZipUrl = $frontendReleaseInfo.assets.browser_download_url
           Write-Host "`e[32mDownload latest frontend zip and build image"
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to a GitHub Actions composite step; primary impact is that fetching the latest release may now fail if the provided token lacks access.
> 
> **Overview**
> When `frontendZipUrl` is set to `latest`, the composite action now sends an **authenticated** `Invoke-RestMethod` request to `api.github.com` by exporting `GH_TOKEN` and adding `Authorization`, `Accept`, and `X-GitHub-Api-Version` headers.
> 
> This reduces the chance of rate-limits/unauthorized responses when resolving the latest `vc-frontend` release asset URL prior to building the frontend Docker image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9748649ee0d9f09082b3964e062bd3f40e8dbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->