### PR TITLE
VCCST-4761: Add an option to use a prebuild docker image for local docker environment installation

### DIFF
--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -202,34 +202,7 @@ runs:
         docker build -f ./nginx/Dockerfile -t "${{ inputs.frontendImage }}:${{ inputs.frontendDockerTag }}" .
         Write-Host "::endgroup::"
 
-    - name: Start database container only
-      env:
-        PLATFORM_IMAGE: ${{ inputs.platformImage }}
-        PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
-        ENV_DIR: ${{ inputs.envDir }}
-      shell: pwsh
-      working-directory: ${{ github.action_path }}
-      run: |
-        Write-Host "`e[33mStart Database Container step started."
-        # for the case of install modules
-        echo "inputs.installModules is ${{ inputs.installModules }}"
-        if ( '${{ inputs.installModules }}' -eq 'true' ){
-          Write-host "Start modify docker-compose.yml"
-          Install-Module -Name powershell-yaml -Force -allowClobber
-          $parsedYaml = Get-Content -Path ./docker-compose.yml -Raw | ConvertFrom-Yaml 
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/modules:/opt/virtocommerce/platform/modules')
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/app_data:/opt/virtocommerce/platform/app_data')
-          $parsedYaml | ConvertTo-Yaml | Set-Content ./docker-compose.yml
-          cat ./docker-compose.yml
-          Write-Host "`e[32mDocker-compose.yml modified"
-        }
-        # Start only the database and elasticsearch containers first
-        Write-Host "::group::Start Database and Elasticsearch containers"
-        docker compose --project-name virtocommerce up -d vc-db es
-        Write-Host "::endgroup::"
-        Write-Host "`e[32mDatabase and Elasticsearch containers started."
-
-    - name: Start remaining containers
+    - name: Start containers
       env:
         PLATFORM_IMAGE: ${{ inputs.platformImage }}
         PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
@@ -238,12 +211,21 @@ runs:
       shell: pwsh
       working-directory: ${{ github.action_path }}
       run: |
-        Write-Host "`e[33mStart Remaining Containers step started."
+        Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-        
-        # Start the remaining containers (platform and frontend)
-        Write-Host "::group::Start Remaining Containers"
+
+        if ( '${{ inputs.installModules }}' -eq 'true' ){
+          Write-Host "Modify docker-compose.yml to mount installed modules"
+          Install-Module -Name powershell-yaml -Force -allowClobber
+          $parsedYaml = Get-Content -Path ./docker-compose.yml -Raw | ConvertFrom-Yaml
+          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/modules:/opt/virtocommerce/platform/modules')
+          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/app_data:/opt/virtocommerce/platform/app_data')
+          $parsedYaml | ConvertTo-Yaml | Set-Content ./docker-compose.yml
+          cat ./docker-compose.yml
+        }
+
+        Write-Host "::group::Start containers"
         docker compose --project-name virtocommerce up -d
         Write-Host "::endgroup::"
         InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -87,7 +87,7 @@ runs:
 
     - name: Download prebuilt platform image artifact
       if: ${{ inputs.prebuiltImageArtifact != '' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.prebuiltImageArtifact }}
         path: ${{ runner.temp }}/prebuilt-image

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -63,15 +63,15 @@ inputs:
     description: 'Directory with environment files'
     required: false
     default: '.'
-  prebuiltImagePath:
-    description: 'Path to a docker save tar to load as the platform image instead of building or pulling. When set, installModules / installCustomModule / customPackagesJsonUrl must be unset.'
+  prebuiltImageArtifact:
+    description: 'Name of a workflow artifact containing a docker save tar of the platform image. When set, the action downloads and loads it instead of building or pulling, and installModules / installCustomModule / customPackagesJsonUrl must be unset.'
     required: false
     default: ''
 runs:
   using: "composite"
   steps:
     - name: Validate prebuilt image configuration
-      if: ${{ inputs.prebuiltImagePath != '' }}
+      if: ${{ inputs.prebuiltImageArtifact != '' }}
       shell: bash
       env:
         INSTALL_MODULES: ${{ inputs.installModules }}
@@ -85,14 +85,23 @@ runs:
         [[ -n "$CUSTOM_PACKAGES_JSON_URL" ]]     && err "customPackagesJsonUrl must be empty — build step would overwrite the loaded image tag."
         exit $fail
 
+    - name: Download prebuilt platform image artifact
+      if: ${{ inputs.prebuiltImageArtifact != '' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.prebuiltImageArtifact }}
+        path: ${{ runner.temp }}/prebuilt-image
+
     - name: Load prebuilt platform image
-      if: ${{ inputs.prebuiltImagePath != '' }}
+      if: ${{ inputs.prebuiltImageArtifact != '' }}
       shell: bash
       env:
-        IMAGE_PATH: ${{ inputs.prebuiltImagePath }}
+        ARTIFACT_DIR: ${{ runner.temp }}/prebuilt-image
         TARGET: ${{ inputs.platformImage }}:${{ inputs.platformDockerTag }}
       run: |
-        loaded=$(docker load -i "$IMAGE_PATH" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
+        image_path=$(find "$ARTIFACT_DIR" -maxdepth 2 -name '*.tar' | head -n1)
+        [[ -n "$image_path" ]] || { echo "::error::no *.tar found in artifact at $ARTIFACT_DIR"; exit 1; }
+        loaded=$(docker load -i "$image_path" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
         [[ -n "$loaded" ]] || { echo "::error::docker load did not report an image ref"; exit 1; }
         [[ "$loaded" == "$TARGET" ]] || docker tag "$loaded" "$TARGET"
         docker image inspect "$TARGET" >/dev/null

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -63,9 +63,41 @@ inputs:
     description: 'Directory with environment files'
     required: false
     default: '.'
+  prebuiltImagePath:
+    description: 'Path to a docker save tar to load as the platform image instead of building or pulling. When set, installModules / installCustomModule / customPackagesJsonUrl must be unset.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
+    - name: Validate prebuilt image configuration
+      if: ${{ inputs.prebuiltImagePath != '' }}
+      shell: bash
+      env:
+        INSTALL_MODULES: ${{ inputs.installModules }}
+        INSTALL_CUSTOM_MODULE: ${{ inputs.installCustomModule }}
+        CUSTOM_PACKAGES_JSON_URL: ${{ inputs.customPackagesJsonUrl }}
+      run: |
+        fail=0
+        err() { echo "::error::$1"; fail=1; }
+        [[ "$INSTALL_MODULES" == "true" ]]       && err "installModules must be 'false' — volume mount would shadow baked-in modules."
+        [[ "$INSTALL_CUSTOM_MODULE" == "true" ]] && err "installCustomModule must be 'false' — build step would overwrite the loaded image tag."
+        [[ -n "$CUSTOM_PACKAGES_JSON_URL" ]]     && err "customPackagesJsonUrl must be empty — build step would overwrite the loaded image tag."
+        exit $fail
+
+    - name: Load prebuilt platform image
+      if: ${{ inputs.prebuiltImagePath != '' }}
+      shell: bash
+      env:
+        IMAGE_PATH: ${{ inputs.prebuiltImagePath }}
+        TARGET: ${{ inputs.platformImage }}:${{ inputs.platformDockerTag }}
+      run: |
+        loaded=$(docker load -i "$IMAGE_PATH" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
+        [[ -n "$loaded" ]] || { echo "::error::docker load did not report an image ref"; exit 1; }
+        [[ "$loaded" == "$TARGET" ]] || docker tag "$loaded" "$TARGET"
+        docker image inspect "$TARGET" >/dev/null
+        echo "Loaded $loaded -> $TARGET"
+
     - name: Use custom packages.json and build platform docker image
       if: ${{ inputs.customPackagesJsonUrl != '' }}
       working-directory: ${{ github.action_path }}

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -250,7 +250,7 @@ runs:
         Write-Host "`e[32mAll containers started."
         
     - name: Check Installed Modules
-      if: ${{ inputs.installModules == 'true' || inputs.installCustomModule == 'true' || inputs.customPackagesJsonUrl != '' }}
+      if: ${{ inputs.installModules == 'true' || inputs.installCustomModule == 'true' || inputs.customPackagesJsonUrl != '' || inputs.prebuiltImageArtifact != '' }}
       working-directory: ${{ github.action_path }}
       shell: pwsh
       run: |

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -120,8 +120,10 @@ runs:
         echo "$load_output"
         # Prefer a Loaded image: line whose repo segment matches the target name,
         # so multi-tag tars don't have us retag an arbitrary unrelated ref.
+        # `|| true` swallows grep's exit 1 under pipefail when no ref matches —
+        # the next block handles the empty result.
         target_name="${TARGET%%:*}"
-        loaded=$(printf '%s\n' "$load_output" | sed -n 's/^Loaded image: //p' | grep -E "(^|/)${target_name}:" | head -n1)
+        loaded=$(printf '%s\n' "$load_output" | sed -n 's/^Loaded image: //p' | { grep -E "(^|/)${target_name}:" || true; } | head -n1)
         if [[ -z "$loaded" ]]; then
           loaded=$(printf '%s\n' "$load_output" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
         fi

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -68,7 +68,15 @@ inputs:
     required: false
     default: 'sqlserver'
   prebuiltImageArtifact:
-    description: 'Name of a workflow artifact containing a docker save tar of the platform image. When set, the action downloads and loads it instead of building or pulling, and installModules / installCustomModule / customPackagesJsonUrl must be unset.'
+    description: |
+      Name of a workflow artifact containing a `docker save` tar of the platform image.
+      When set, the action downloads and `docker load`s it instead of building or pulling.
+
+      BREAKING CONTRACT — when this input is set, the following inputs MUST be at the listed values
+      (the action will fail-fast with an actionable error otherwise):
+        - installModules:        'false'  (a volume mount would otherwise shadow the baked-in modules)
+        - installCustomModule:   'false'  (the build step would overwrite the loaded image tag)
+        - customPackagesJsonUrl: ''       (the build step would overwrite the loaded image tag)
     required: false
     default: ''
 runs:
@@ -84,9 +92,12 @@ runs:
       run: |
         fail=0
         err() { echo "::error::$1"; fail=1; }
-        [[ "$INSTALL_MODULES" == "true" ]]       && err "installModules must be 'false' — volume mount would shadow baked-in modules."
-        [[ "$INSTALL_CUSTOM_MODULE" == "true" ]] && err "installCustomModule must be 'false' — build step would overwrite the loaded image tag."
-        [[ -n "$CUSTOM_PACKAGES_JSON_URL" ]]     && err "customPackagesJsonUrl must be empty — build step would overwrite the loaded image tag."
+        [[ "$INSTALL_MODULES" == "true" ]]       && err "prebuiltImageArtifact requires installModules='false' — a volume mount would shadow baked-in modules. Set installModules: 'false' on the caller side."
+        [[ "$INSTALL_CUSTOM_MODULE" == "true" ]] && err "prebuiltImageArtifact requires installCustomModule='false' — the build step would overwrite the loaded image tag. Set installCustomModule: 'false' on the caller side."
+        [[ -n "$CUSTOM_PACKAGES_JSON_URL" ]]     && err "prebuiltImageArtifact requires customPackagesJsonUrl='' — the build step would overwrite the loaded image tag. Unset customPackagesJsonUrl on the caller side."
+        if [[ $fail -ne 0 ]]; then
+          echo "::error::Incompatible inputs combined with prebuiltImageArtifact. See the input description for the full contract."
+        fi
         exit $fail
 
     - name: Download prebuilt platform image artifact
@@ -103,9 +114,17 @@ runs:
         ARTIFACT_DIR: ${{ runner.temp }}/prebuilt-image
         TARGET: ${{ inputs.platformImage }}:${{ inputs.platformDockerTag }}
       run: |
-        image_path=$(find "$ARTIFACT_DIR" -maxdepth 2 -name '*.tar' | head -n1)
+        image_path=$(find "$ARTIFACT_DIR" -maxdepth 2 -type f -name '*.tar' | head -n1)
         [[ -n "$image_path" ]] || { echo "::error::no *.tar found in artifact at $ARTIFACT_DIR"; exit 1; }
-        loaded=$(docker load -i "$image_path" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
+        load_output=$(docker load -i "$image_path")
+        echo "$load_output"
+        # Prefer a Loaded image: line whose repo segment matches the target name,
+        # so multi-tag tars don't have us retag an arbitrary unrelated ref.
+        target_name="${TARGET%%:*}"
+        loaded=$(printf '%s\n' "$load_output" | sed -n 's/^Loaded image: //p' | grep -E "(^|/)${target_name}:" | head -n1)
+        if [[ -z "$loaded" ]]; then
+          loaded=$(printf '%s\n' "$load_output" | sed -n -e 's/^Loaded image: //p' -e 's/^Loaded image ID: //p' | head -n1)
+        fi
         [[ -n "$loaded" ]] || { echo "::error::docker load did not report an image ref"; exit 1; }
         [[ "$loaded" == "$TARGET" ]] || docker tag "$loaded" "$TARGET"
         docker image inspect "$TARGET" >/dev/null
@@ -232,12 +251,14 @@ runs:
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
 
-    - name: Start containers
+    - name: Start database and elasticsearch containers
       env:
         PLATFORM_IMAGE: ${{ inputs.platformImage }}
         PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
         ENV_DIR: ${{ inputs.envDir }}
         SENDGRID_API_KEY: ${{ inputs.sendgridApiKey }}
+        INSTALL_MODULES: ${{ inputs.installModules }}
+        DB_PROVIDER: ${{ inputs.databaseProvider }}
       shell: pwsh
       working-directory: ${{ github.action_path }}
       run: |
@@ -245,7 +266,7 @@ runs:
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
 
-        if ( '${{ inputs.installModules }}' -eq 'true' ){
+        if ( $env:INSTALL_MODULES -eq 'true' ){
           Write-Host "Modify docker-compose.yml to mount installed modules"
           Install-Module -Name powershell-yaml -Force -allowClobber
           $parsedYaml = Get-Content -Path ./docker-compose.yml -Raw | ConvertFrom-Yaml
@@ -256,7 +277,7 @@ runs:
         }
         # Start only the database and elasticsearch containers first
         Write-Host "::group::Start Database and Elasticsearch containers"
-        docker compose --project-name virtocommerce -f docker-compose.yml -f docker-compose.${{ inputs.databaseProvider }}.yml up -d vc-db es
+        docker compose --project-name virtocommerce -f docker-compose.yml -f "docker-compose.$env:DB_PROVIDER.yml" up -d vc-db es
         Write-Host "::endgroup::"
         Write-Host "`e[32mDatabase and Elasticsearch containers started."
 
@@ -266,16 +287,17 @@ runs:
         PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
         ENV_DIR: ${{ inputs.envDir }}
         SENDGRID_API_KEY: ${{ inputs.sendgridApiKey }}
+        DB_PROVIDER: ${{ inputs.databaseProvider }}
       shell: pwsh
       working-directory: ${{ github.action_path }}
       run: |
         Write-Host "`e[33mStart Remaining Containers step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-        
+
         # Start the remaining containers (platform and frontend)
         Write-Host "::group::Start Remaining Containers"
-        docker compose --project-name virtocommerce -f docker-compose.yml -f docker-compose.${{ inputs.databaseProvider }}.yml up -d
+        docker compose --project-name virtocommerce -f docker-compose.yml -f "docker-compose.$env:DB_PROVIDER.yml" up -d
         Write-Host "::endgroup::"
         InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0
         Write-Host "`e[32mAll containers started."

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -145,9 +145,8 @@ runs:
         # pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
         #   --junitxml=report/graphql-junit.xml
 
-        echo "+ pytest tests/graphql -m 'not ignore and not optional' -v -s --color=yes --junitxml=report/graphql-junit.xml"
-        pytest tests/graphql -m "not ignore and not optional" -v -s --color=yes \
-          --junitxml=report/graphql-junit.xml
+        echo "+ pytest tests/graphql -v -s --color=yes --junitxml=report/graphql-junit.xml -m 'not ignore and not optional'"
+        pytest tests/graphql -v -s --color=yes --junitxml=report/graphql-junit.xml -m 'not ignore and not optional'
 
         echo "::endgroup::"
 

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -141,8 +141,8 @@ runs:
         echo "::group::GraphQL tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
-          --junitxml=report/graphql-junit.xml
+        ( set -x; pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
+          --junitxml=report/graphql-junit.xml )
         echo "::endgroup::"
 
     - name: Run E2E tests
@@ -155,8 +155,8 @@ runs:
         echo "::group::E2E tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
-          --junitxml=report/e2e-junit.xml
+        ( set -x; pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
+          --junitxml=report/e2e-junit.xml )
         echo "::endgroup::"
 
     - name: Run REST API tests (parallel-safe)
@@ -169,8 +169,8 @@ runs:
         echo "::group::REST API tests (parallel-safe)"
         MARKERS="restapi and not ignore and not serial"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
-          --junitxml=report/restapi-junit.xml
+        ( set -x; pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
+          --junitxml=report/restapi-junit.xml )
         echo "::endgroup::"
 
     - name: Run REST API tests (serial — global state mutators)
@@ -183,9 +183,9 @@ runs:
         echo "::group::REST API tests (serial)"
         MARKERS="restapi and serial and not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
+        ( set -x; pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
           --junitxml=report/restapi-serial-junit.xml \
-          --deselect tests/restapi/platform/test_misc.py::test_restart_platform
+          --deselect tests/restapi/platform/test_misc.py::test_restart_platform )
         echo "::endgroup::"
 
     - name: Run REST API test — restart platform (last)
@@ -198,8 +198,8 @@ runs:
         echo "::group::REST API restart-platform test"
         MARKER_ARGS=()
         [ -n "$PYTEST_MARKERS" ] && MARKER_ARGS=(-m "$PYTEST_MARKERS")
-        pytest tests/restapi/platform/test_misc.py::test_restart_platform "${MARKER_ARGS[@]}" -v -s --color=yes \
-          --junitxml=report/restapi-restart-junit.xml
+        ( set -x; pytest tests/restapi/platform/test_misc.py::test_restart_platform "${MARKER_ARGS[@]}" -v -s --color=yes \
+          --junitxml=report/restapi-restart-junit.xml )
         echo "::endgroup::"
 
     - name: Install Allure CLI

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -157,12 +157,13 @@ runs:
       working-directory: ${{ inputs.vctestingPath }}
       env:
         PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
+        BROWSER: ${{ inputs.browser }}
       run: |
         echo "::group::E2E tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        echo "+ pytest tests/e2e -m '$MARKERS' --browser ${{ inputs.browser }} -v -s --color=yes --junitxml=report/e2e-junit.xml"
-        pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
+        echo "+ pytest tests/e2e -m '$MARKERS' --browser '$BROWSER' -v -s --color=yes --junitxml=report/e2e-junit.xml"
+        pytest tests/e2e -m "$MARKERS" --browser "$BROWSER" -v -s --color=yes \
           --junitxml=report/e2e-junit.xml
         echo "::endgroup::"
 
@@ -205,6 +206,9 @@ runs:
         PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::REST API restart-platform test"
+        # Unlike the other suites, this step has no default marker expression
+        # (it targets a single test by node-id), so an empty -m must be omitted
+        # entirely — passing `-m ""` would deselect everything.
         MARKER_ARGS=()
         MARKER_ECHO=""
         if [ -n "$PYTEST_MARKERS" ]; then

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -25,6 +25,11 @@ inputs:
     description: 'Browser'
     required: true
     type: string
+  pytestMarkers:
+    description: 'Additional pytest -m marker expression, AND-combined with each suite''s default markers. Leave empty to use defaults only.'
+    required: false
+    default: ''
+    type: string
   testSecretEnvFile:
     description: 'Test secret environment file content'
     required: true
@@ -130,9 +135,13 @@ runs:
       shell: bash
       if: (success() || failure()) && steps.seed.outcome == 'success' && contains(inputs.testSuites, 'graphql')
       working-directory: ${{ inputs.vctestingPath }}
+      env:
+        PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::GraphQL tests"
-        pytest tests/graphql -m "not ignore" -v -s --color=yes \
+        MARKERS="not ignore"
+        [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
+        pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
           --junitxml=report/graphql-junit.xml
         echo "::endgroup::"
 
@@ -140,9 +149,13 @@ runs:
       shell: bash
       if: (success() || failure()) && steps.seed.outcome == 'success' && contains(inputs.testSuites, 'e2e')
       working-directory: ${{ inputs.vctestingPath }}
+      env:
+        PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::E2E tests"
-        pytest tests/e2e -m "not ignore" --browser ${{ inputs.browser }} -v -s --color=yes \
+        MARKERS="not ignore"
+        [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
+        pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
           --junitxml=report/e2e-junit.xml
         echo "::endgroup::"
 
@@ -150,9 +163,13 @@ runs:
       shell: bash
       if: (success() || failure()) && steps.seed.outcome == 'success' && contains(inputs.testSuites, 'restapi')
       working-directory: ${{ inputs.vctestingPath }}
+      env:
+        PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::REST API tests (parallel-safe)"
-        pytest tests/restapi -m "restapi and not ignore and not serial" -v -s --color=yes \
+        MARKERS="restapi and not ignore and not serial"
+        [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
+        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
           --junitxml=report/restapi-junit.xml
         echo "::endgroup::"
 
@@ -160,9 +177,13 @@ runs:
       shell: bash
       if: (success() || failure()) && steps.seed.outcome == 'success' && contains(inputs.testSuites, 'restapi')
       working-directory: ${{ inputs.vctestingPath }}
+      env:
+        PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::REST API tests (serial)"
-        pytest tests/restapi -m "restapi and serial and not ignore" -v -s --color=yes \
+        MARKERS="restapi and serial and not ignore"
+        [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
+        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
           --junitxml=report/restapi-serial-junit.xml \
           --deselect tests/restapi/platform/test_misc.py::test_restart_platform
         echo "::endgroup::"
@@ -171,9 +192,13 @@ runs:
       shell: bash
       if: (success() || failure()) && steps.seed.outcome == 'success' && contains(inputs.testSuites, 'restapi')
       working-directory: ${{ inputs.vctestingPath }}
+      env:
+        PYTEST_MARKERS: ${{ inputs.pytestMarkers }}
       run: |
         echo "::group::REST API restart-platform test"
-        pytest tests/restapi/platform/test_misc.py::test_restart_platform -v -s --color=yes \
+        MARKER_ARGS=()
+        [ -n "$PYTEST_MARKERS" ] && MARKER_ARGS=(-m "$PYTEST_MARKERS")
+        pytest tests/restapi/platform/test_misc.py::test_restart_platform "${MARKER_ARGS[@]}" -v -s --color=yes \
           --junitxml=report/restapi-restart-junit.xml
         echo "::endgroup::"
 

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -141,8 +141,9 @@ runs:
         echo "::group::GraphQL tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        ( set -x; pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
-          --junitxml=report/graphql-junit.xml )
+        echo "+ pytest tests/graphql -m '$MARKERS' -v -s --color=yes --junitxml=report/graphql-junit.xml"
+        pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
+          --junitxml=report/graphql-junit.xml
         echo "::endgroup::"
 
     - name: Run E2E tests
@@ -155,8 +156,9 @@ runs:
         echo "::group::E2E tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        ( set -x; pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
-          --junitxml=report/e2e-junit.xml )
+        echo "+ pytest tests/e2e -m '$MARKERS' --browser ${{ inputs.browser }} -v -s --color=yes --junitxml=report/e2e-junit.xml"
+        pytest tests/e2e -m "$MARKERS" --browser ${{ inputs.browser }} -v -s --color=yes \
+          --junitxml=report/e2e-junit.xml
         echo "::endgroup::"
 
     - name: Run REST API tests (parallel-safe)
@@ -169,8 +171,9 @@ runs:
         echo "::group::REST API tests (parallel-safe)"
         MARKERS="restapi and not ignore and not serial"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        ( set -x; pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
-          --junitxml=report/restapi-junit.xml )
+        echo "+ pytest tests/restapi -m '$MARKERS' -v -s --color=yes --junitxml=report/restapi-junit.xml"
+        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
+          --junitxml=report/restapi-junit.xml
         echo "::endgroup::"
 
     - name: Run REST API tests (serial — global state mutators)
@@ -183,9 +186,10 @@ runs:
         echo "::group::REST API tests (serial)"
         MARKERS="restapi and serial and not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        ( set -x; pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
+        echo "+ pytest tests/restapi -m '$MARKERS' -v -s --color=yes --junitxml=report/restapi-serial-junit.xml --deselect tests/restapi/platform/test_misc.py::test_restart_platform"
+        pytest tests/restapi -m "$MARKERS" -v -s --color=yes \
           --junitxml=report/restapi-serial-junit.xml \
-          --deselect tests/restapi/platform/test_misc.py::test_restart_platform )
+          --deselect tests/restapi/platform/test_misc.py::test_restart_platform
         echo "::endgroup::"
 
     - name: Run REST API test — restart platform (last)
@@ -197,9 +201,14 @@ runs:
       run: |
         echo "::group::REST API restart-platform test"
         MARKER_ARGS=()
-        [ -n "$PYTEST_MARKERS" ] && MARKER_ARGS=(-m "$PYTEST_MARKERS")
-        ( set -x; pytest tests/restapi/platform/test_misc.py::test_restart_platform "${MARKER_ARGS[@]}" -v -s --color=yes \
-          --junitxml=report/restapi-restart-junit.xml )
+        MARKER_ECHO=""
+        if [ -n "$PYTEST_MARKERS" ]; then
+          MARKER_ARGS=(-m "$PYTEST_MARKERS")
+          MARKER_ECHO=" -m '$PYTEST_MARKERS'"
+        fi
+        echo "+ pytest tests/restapi/platform/test_misc.py::test_restart_platform${MARKER_ECHO} -v -s --color=yes --junitxml=report/restapi-restart-junit.xml"
+        pytest tests/restapi/platform/test_misc.py::test_restart_platform "${MARKER_ARGS[@]}" -v -s --color=yes \
+          --junitxml=report/restapi-restart-junit.xml
         echo "::endgroup::"
 
     - name: Install Allure CLI

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -141,9 +141,14 @@ runs:
         echo "::group::GraphQL tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        echo "+ pytest tests/graphql -m '$MARKERS' -v -s --color=yes --junitxml=report/graphql-junit.xml"
-        pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
+        # echo "+ pytest tests/graphql -m '$MARKERS' -v -s --color=yes --junitxml=report/graphql-junit.xml"
+        # pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
+        #   --junitxml=report/graphql-junit.xml
+
+        echo "+ pytest tests/graphql -m 'not ignore and not optional' -v -s --color=yes --junitxml=report/graphql-junit.xml"
+        pytest tests/graphql -m "not ignore and not optional" -v -s --color=yes \
           --junitxml=report/graphql-junit.xml
+
         echo "::endgroup::"
 
     - name: Run E2E tests

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -141,13 +141,9 @@ runs:
         echo "::group::GraphQL tests"
         MARKERS="not ignore"
         [ -n "$PYTEST_MARKERS" ] && MARKERS="($MARKERS) and ($PYTEST_MARKERS)"
-        # echo "+ pytest tests/graphql -m '$MARKERS' -v -s --color=yes --junitxml=report/graphql-junit.xml"
-        # pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
-        #   --junitxml=report/graphql-junit.xml
-
-        echo "+ pytest tests/graphql -v -s --color=yes --junitxml=report/graphql-junit.xml -m 'not ignore and not optional'"
-        pytest tests/graphql -v -s --color=yes --junitxml=report/graphql-junit.xml -m 'not ignore and not optional'
-
+        echo "+ pytest tests/graphql -m '$MARKERS' -v -s --color=yes --junitxml=report/graphql-junit.xml"
+        pytest tests/graphql -m "$MARKERS" -v -s --color=yes \
+          --junitxml=report/graphql-junit.xml
         echo "::endgroup::"
 
     - name: Run E2E tests


### PR DESCRIPTION
- docker-env-full: add prebuiltImageArtifact input that downloads a workflow artifact and docker loads the platform image instead of building/pulling it, with up-front validation of incompatible inputs (installModules, installCustomModule, customPackagesJsonUrl) and name-matched parsing of the docker load output. Hardened PowerShell steps by routing installModules and databaseProvider through env: instead of ${{ inputs.* }} interpolation. Renamed the partial-start step to accurately reflect that it only brings up the database and elasticsearch.

- run-pytest-tests: add pytestMarkers input that AND-combines a caller-supplied -m expression with each suite's existing default markers; applied to all five pytest invocations including the restart-platform step. Each pytest call is now preceded by a stdout + pytest … echo of the resolved command for log traceability. Routed --browser through env: to remove an expression-injection surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes composite GitHub Actions behavior for building/starting Docker environments and running test suites, which can break CI runs if the new inputs or validation contracts are misconfigured. Also touches docker image loading/tagging logic and pytest selection, which may alter what gets executed.
> 
> **Overview**
> Adds an optional `prebuiltImageArtifact` input to `docker-env-full` to **download and `docker load` a prebuilt platform image** instead of building/pulling it, with fail-fast validation to prevent incompatible combinations (`installModules`, `installCustomModule`, `customPackagesJsonUrl`) and safer parsing/retagging of `docker load` output.
> 
> Hardens container-start steps by routing `installModules`/`databaseProvider` through `env` variables (rather than direct input interpolation) and updates module verification to also run when a prebuilt image is used.
> 
> Extends `run-pytest-tests` with a `pytestMarkers` input that **AND-combines caller-supplied markers** with each suite’s defaults (handling the single-test restart step specially), logs the resolved pytest command, and routes `--browser` via `env` to reduce expression-injection surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef897dd9407fa0b6f8d37053ea4c3cfbb894010a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->