### PR TITLE
VCST-4843: Pin third-party actions to SHAs and automate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /**
+    directories: /**
     schedule:
       interval: weekly
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directory: /**
     schedule:
       interval: weekly
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directories: /**
+    directories: ["/**"]
     schedule:
       interval: weekly
     groups:

--- a/.github/workflows/docker-env-test.yml
+++ b/.github/workflows/docker-env-test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.pkg.github.com
           username: $GITHUB_ACTOR

--- a/.github/workflows/jira-pr-webook-create.yaml
+++ b/.github/workflows/jira-pr-webook-create.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Create create Jira issue for contribution PR webhook
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         github-token: ${{ secrets.REPO_TOKEN }}
         script: |

--- a/.github/workflows/katalon-report.yml
+++ b/.github/workflows/katalon-report.yml
@@ -20,7 +20,7 @@ jobs:
 
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.pkg.github.com
           username: $GITHUB_ACTOR
@@ -50,7 +50,7 @@ jobs:
 
       - name: Katalon TestOps Report Uploader
         if: always()
-        uses: katalon-studio/report-uploader@v0.0.8
+        uses: katalon-studio/report-uploader@323ea44c0b05cf6aa9f0b9e74439a7a17428e11a # v0.0.8
         env:
           PASSWORD: ${{ secrets.KATALON_API_KEY }}
           PROJECT_ID: 263280
@@ -59,7 +59,7 @@ jobs:
 
       - name: 'Katalon Reports'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reports
           path: |

--- a/.github/workflows/katalon.yml
+++ b/.github/workflows/katalon.yml
@@ -74,7 +74,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Getting tests
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: ${{ env.KATALON_REPO }}
         ref: ${{ env.KATALON_REPO_BRANCH }}
@@ -97,7 +97,7 @@ jobs:
         envDir: '${{ github.workspace }}'
         
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: 'zulu'
         java-version: '8'
@@ -111,7 +111,7 @@ jobs:
 
     - name: Katalon Report Uploader
       if: always()
-      uses: katalon-studio/report-uploader@v0.0.8
+      uses: katalon-studio/report-uploader@323ea44c0b05cf6aa9f0b9e74439a7a17428e11a # v0.0.8
       env:
         PASSWORD: ${{ secrets.KATALON_API_KEY }}
         PROJECT_ID: 171535
@@ -120,7 +120,7 @@ jobs:
 
     - name: Save Katalon Report as workflow artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: reports
         path: |

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-        - uses: actions/setup-node@v1
+        - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
           with:
             node-version: '12.x'
             registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.pkg.github.com
           username: $GITHUB_ACTOR
@@ -35,7 +35,7 @@ jobs:
           Write-Output "::set-output name=storefrontIP::$($storefrontIP)"
 
       - name: OWASP ZAP Full Scan
-        uses: zaproxy/action-baseline@v0.4.0
+        uses: zaproxy/action-baseline@acd8e997263688cb49cb5ff8247a4b2758c548ab # v0.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,34 @@
+name: Verify action pinning
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '**/action.yml'
+      - '**/action.yaml'
+      - '.pinact.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    env:
+      PINACT_VERSION: v3.10.1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install pinact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd "$RUNNER_TEMP"
+          gh release download "$PINACT_VERSION" \
+            --repo suzuki-shunsuke/pinact \
+            --pattern 'pinact_linux_amd64.tar.gz'
+          tar -xzf pinact_linux_amd64.tar.gz
+          sudo install pinact /usr/local/bin/
+
+      - name: Verify all third-party actions are pinned to SHAs
+        run: pinact run -check

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -16,12 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PINACT_VERSION: v3.10.1
+      # Used by `gh release download` and by pinact when calling the GitHub
+      # REST API to resolve latest tag SHAs. Without this, pinact falls back
+      # to unauthenticated requests (60/hour) and the update will likely
+      # rate-limit. GH_TOKEN is the alias gh CLI prefers; pinact reads
+      # GITHUB_TOKEN.
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install pinact
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           cd "$RUNNER_TEMP"
           gh release download "$PINACT_VERSION" \

--- a/.github/workflows/remove-file.yml
+++ b/.github/workflows/remove-file.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: '${{ github.repository_owner }}/${{ matrix.repoName }}'
         ref: '${{ github.event.inputs.branchName }}'

--- a/.github/workflows/suiteDebug.yml
+++ b/.github/workflows/suiteDebug.yml
@@ -20,7 +20,7 @@ jobs:
 
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.pkg.github.com
           username: $GITHUB_ACTOR
@@ -54,7 +54,7 @@ jobs:
 
       - name: Katalon Report Uploader
         if: always()
-        uses: katalon-studio/report-uploader@v0.0.8
+        uses: katalon-studio/report-uploader@323ea44c0b05cf6aa9f0b9e74439a7a17428e11a # v0.0.8
         env:
           PASSWORD: ${{ secrets.KATALON_API_KEY }}
           PROJECT_ID: 263280
@@ -64,7 +64,7 @@ jobs:
 
       - name: 'Katalon Reports'
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reports
           path: |

--- a/.github/workflows/virtocommerce-docs-2.yml
+++ b/.github/workflows/virtocommerce-docs-2.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
            # Number of commits to fetch. 0 indicates all history.
            # Default: 1
            fetch-depth: 0    
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.8.x'
 

--- a/.github/workflows/virtocommerce.yml
+++ b/.github/workflows/virtocommerce.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
            # Number of commits to fetch. 0 indicates all history.
            # Default: 1
            fetch-depth: 0    
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.8.x'
 

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ^\.github/workflows/.*\.ya?ml$
+  - pattern: ^(.*/)?action\.ya?ml$
+
+ignore_actions:
+  - name: VirtoCommerce/.*
+    ref: .*

--- a/README.md
+++ b/README.md
@@ -121,3 +121,31 @@ VirtoCommerce specific GitHub actions and actions common components lib.
 * [Swagger validation](/docker-env/README.md)
 * [Sync Modules Workflows](/sync-module-cicd/README.md)
 * [Actions components lib](/vc-actions-lib/README.md)
+
+## Supply-chain security: pinned third-party actions
+
+Every third-party `uses:` reference in this repo (anything not under `VirtoCommerce/*`) is pinned to a full 40-character commit SHA with a trailing `# tag` comment, per the [GitHub Actions hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). Tags are mutable; SHAs are not.
+
+```yaml
+# Correct
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+# Rejected by CI
+uses: actions/checkout@v6
+```
+
+**How updates happen**
+
+- **Dependabot** (`.github/dependabot.yml`) scans `.github/workflows/` and every `**/action.yml` weekly. When upstream cuts a new tag, it opens a grouped PR bumping the SHA + trailing comment.
+- **Pin-check CI** (`.github/workflows/pin-check.yml`) runs `pinact run -check` on every PR that touches workflows or `action.yml` files. PRs with unpinned third-party `uses:` lines fail.
+- **Scope** is configured in [`.pinact.yaml`](.pinact.yaml) — `VirtoCommerce/*` is intentionally ignored (internal, not third-party).
+
+**For contributors**
+
+- When adding a new third-party action, write the SHA, not the tag. Quick lookup:
+
+  ```sh
+  gh api repos/OWNER/REPO/commits/TAG --jq '.sha'
+  ```
+
+- `VirtoCommerce/vc-github-actions/<dir>@master` and other `VirtoCommerce/*` refs remain version-/branch-pinned as before.

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -102,7 +102,7 @@ runs:
 
     - name: Download prebuilt platform image artifact
       if: ${{ inputs.prebuiltImageArtifact != '' }}
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ inputs.prebuiltImageArtifact }}
         path: ${{ runner.temp }}/prebuilt-image

--- a/run-e2e-tests/action.yml
+++ b/run-e2e-tests/action.yml
@@ -41,12 +41,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.11"
 
     - name: Getting tests
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ inputs.vctestingRepo }}
         ref: ${{ inputs.vctestingRepoBranch }}
@@ -103,7 +103,7 @@ runs:
 
     - name: Upload dataset_manager log
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: e2e-dataset-manager-log-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: ${{ inputs.vctestingPath }}/dataset/dataset_manager.log
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: e2e-test-results-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: |

--- a/run-graphql-tests/action.yml
+++ b/run-graphql-tests/action.yml
@@ -41,12 +41,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.11"
 
     - name: Getting tests
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ inputs.vctestingRepo }}
         ref: ${{ inputs.vctestingRepoBranch }}
@@ -103,7 +103,7 @@ runs:
 
     - name: Upload dataset_manager log
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: graphql-dataset-manager-log-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: ${{ inputs.vctestingPath }}/dataset/dataset_manager.log
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: graphql-test-results-${{ inputs.browser }}-${{ github.run_number }}-${{ github.run_attempt }}
         path: |

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -60,12 +60,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.13"
 
     - name: Getting tests
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ inputs.vctestingRepo }}
         ref: ${{ inputs.vctestingRepoBranch }}
@@ -293,7 +293,7 @@ runs:
 
     - name: Upload consolidated test results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: test-results-${{ github.run_number }}-${{ github.run_attempt }}${{ inputs.artifactSuffix }}
         path: ${{ inputs.vctestingPath }}/report/

--- a/update-virtocommerce-docs-versioned/action.yml
+++ b/update-virtocommerce-docs-versioned/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout vc-docs repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: VirtoCommerce/vc-docs
         ref: ${{ inputs.ref }}
@@ -44,7 +44,7 @@ runs:
         persist-credentials: true
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.x"
 


### PR DESCRIPTION
Pins every third-party uses: reference (non-VirtoCommerce/* owners) in .github/workflows/ and workflow-templates/ to a 40-character commit SHA with a trailing # tag comment, per [GitHub's supply-chain hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). Tags are mutable; SHAs are not.

New pinact.yaml declaring scan paths and VirtoCommerce/* ignore.
New .github/workflows/pin-check.yml — runs pinact run -check on every PR that touches workflows or templates; fails on unpinned uses: lines.
Internal VirtoCommerce/* refs (vc-github-actions, jira-upload-*, reusable workflows) are intentionally left as version-/branch-pinned — they're not third-party.

Layers automated maintenance onto the SHA pinning from #.

.github/dependabot.yml — weekly grouped github-actions updates. Dependabot reads the # tag comment, bumps SHA + comment together when upstream cuts new tags.
README updated (incl. how to look up a SHA for a new action).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to CI/workflow configuration, but could cause workflow failures if pinned SHAs are incorrect or pin-check enforcement flags existing patterns.
> 
> **Overview**
> **Hardens GitHub Actions supply chain** by replacing third-party `uses:` tags (e.g., `actions/*`, `docker/*`, `zaproxy/*`, `katalon-studio/*`) with full commit-SHA pins plus `# vX` comments across workflows and composite actions.
> 
> Adds **automated maintenance and enforcement**: new `.github/dependabot.yml` for weekly grouped `github-actions` updates, new `.github/workflows/pin-check.yml` to run `pinact run -check` on PRs touching workflows/actions, and new `.pinact.yaml` to scope scans while ignoring internal `VirtoCommerce/*` actions. Documentation in `README.md` is updated with the pinning policy and contributor guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e60dd98125a30076ae11ecd22768cd68d1aece4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->