### PR TITLE
VCST-5063: Add Application Insights telemetry to the e2e Docker stack

### DIFF
--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -82,13 +82,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Compose Application Insights role name
-      shell: bash
-      run: |
-        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-        echo "ROLE_NAME=${role_name}" >> "$GITHUB_ENV"
-        echo "::notice title=Application Insights role name::${role_name}"
-
     - name: Validate prebuilt image configuration
       if: ${{ inputs.prebuiltImageArtifact != '' }}
       shell: bash
@@ -259,6 +252,8 @@ runs:
         Write-Host "::add-mask::$esPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
+        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB"
+        Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
 
     - name: Start database and elasticsearch containers
       env:

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -265,9 +265,7 @@ runs:
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
         # ROLE_NAME uniquely identifies this platform container instance in Application
         # Insights. It's anchored to the database provider because that's the matrix
-        # dimension that produces a distinct platform container. Caller-defined tags
-        # like artifactSuffix (browser/OS/etc.) live in the test action, NOT here — a
-        # single platform may serve many test bundles with the same ROLE_NAME.
+        # dimension that produces a distinct platform container.
         # Exported via $GITHUB_ENV so downstream actions (e.g. run-pytest-tests) can
         # surface the same value without recomputing it.
         $dbSuffix = if ($env:DB_PROVIDER_INPUT) { "-$env:DB_PROVIDER_INPUT" } else { '' }
@@ -323,8 +321,6 @@ runs:
         Write-Host "`e[33mStart Remaining Containers step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-
-        # Start the remaining containers (platform and frontend)
         Write-Host "::group::Start Remaining Containers"
         docker compose --project-name virtocommerce -f docker-compose.yml -f "docker-compose.$env:DB_PROVIDER.yml" up -d
         Write-Host "::endgroup::"

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -79,8 +79,8 @@ inputs:
         - customPackagesJsonUrl: ''       (the build step would overwrite the loaded image tag)
     required: false
     default: ''
-  appInsightsConnectionString:
-    description: 'Application Insights connection string (format: `InstrumentationKey=<guid>;IngestionEndpoint=https://...;LiveEndpoint=https://...`). Passed to the platform container via APPLICATIONINSIGHTS_CONNECTION_STRING.'
+  appInsightsInstrumentationKey:
+    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`.'
     required: false
     default: ''
 runs:
@@ -241,7 +241,7 @@ runs:
     - name: Generate container secrets
       shell: pwsh
       env:
-        APP_INSIGHTS_CONNECTION_STRING_INPUT: ${{ inputs.appInsightsConnectionString }}
+        APP_INSIGHTS_IKEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
       run: |
         function New-RandomPassword {
           # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
@@ -260,10 +260,10 @@ runs:
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
         $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
-        $aiConnString = $env:APP_INSIGHTS_CONNECTION_STRING_INPUT
-        if ($aiConnString) {
-          Write-Host "::add-mask::$aiConnString"
-          Add-Content -Path $env:GITHUB_ENV -Value "APPLICATIONINSIGHTS_CONNECTION_STRING=$aiConnString"
+        $aiKey = $env:APP_INSIGHTS_IKEY_INPUT
+        if ($aiKey) {
+          Write-Host "::add-mask::$aiKey"
+          Add-Content -Path $env:GITHUB_ENV -Value "APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$aiKey"
         }
 
     - name: Start database and elasticsearch containers

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -172,7 +172,7 @@ runs:
         New-Item -Path "./" -Name "${{ env.INSTALL_FOLDER}}" -ItemType "directory"
         Push-Location ./${{ env.INSTALL_FOLDER}}
         vc-build install -Edge -skip InstallPlatform
-        vc-build install -module VirtoCommerce.Quote VirtoCommerce.XPickup
+        vc-build install -module VirtoCommerce.Quote VirtoCommerce.XPickup VirtoCommerce.MarketingExperienceApi
         Write-Host "`e[32mPull platform docker image to local storage"
         docker pull ghcr.io/virtocommerce/platform:${{ inputs.platformDockerTag }}
         docker tag ghcr.io/virtocommerce/platform:${{ inputs.platformDockerTag }} "${{ inputs.platformImage }}:local-latest"

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -242,6 +242,7 @@ runs:
       shell: pwsh
       env:
         APP_INSIGHTS_IKEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
+        DB_PROVIDER_INPUT: ${{ inputs.databaseProvider }}
       run: |
         function New-RandomPassword {
           # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
@@ -258,7 +259,7 @@ runs:
         Write-Host "::add-mask::$esPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
-        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB"
+        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:DB_PROVIDER_INPUT"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
         $aiKey = $env:APP_INSIGHTS_IKEY_INPUT
         if ($aiKey) {

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -79,8 +79,8 @@ inputs:
         - customPackagesJsonUrl: ''       (the build step would overwrite the loaded image tag)
     required: false
     default: ''
-  appInsightsInstrumentationKey:
-    description: 'Application Insights instrumentation key. Passed to the platform container via APPINSIGHTS:INSTRUMENTATIONKEY.'
+  appInsightsConnectionString:
+    description: 'Application Insights connection string (format: `InstrumentationKey=<guid>;IngestionEndpoint=https://...;LiveEndpoint=https://...`). Passed to the platform container via APPLICATIONINSIGHTS_CONNECTION_STRING.'
     required: false
     default: ''
 runs:
@@ -241,7 +241,7 @@ runs:
     - name: Generate container secrets
       shell: pwsh
       env:
-        APPINSIGHTS_INSTRUMENTATION_KEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
+        APP_INSIGHTS_CONNECTION_STRING_INPUT: ${{ inputs.appInsightsConnectionString }}
       run: |
         function New-RandomPassword {
           # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
@@ -260,10 +260,10 @@ runs:
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
         $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
-        $iKey = $env:APPINSIGHTS_INSTRUMENTATION_KEY_INPUT
-        if ($iKey) {
-          Write-Host "::add-mask::$iKey"
-          Add-Content -Path $env:GITHUB_ENV -Value "APPINSIGHTS_INSTRUMENTATIONKEY=$iKey"
+        $aiConnString = $env:APP_INSIGHTS_CONNECTION_STRING_INPUT
+        if ($aiConnString) {
+          Write-Host "::add-mask::$aiConnString"
+          Add-Content -Path $env:GITHUB_ENV -Value "APPLICATIONINSIGHTS_CONNECTION_STRING=$aiConnString"
         }
 
     - name: Start database and elasticsearch containers

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -82,6 +82,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Compose Application Insights role name
+      shell: bash
+      run: |
+        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        echo "ROLE_NAME=${role_name}" >> "$GITHUB_ENV"
+        echo "::notice title=Application Insights role name::${role_name}"
+
     - name: Validate prebuilt image configuration
       if: ${{ inputs.prebuiltImageArtifact != '' }}
       shell: bash

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -79,6 +79,10 @@ inputs:
         - customPackagesJsonUrl: ''       (the build step would overwrite the loaded image tag)
     required: false
     default: ''
+  appInsightsInstrumentationKey:
+    description: 'Application Insights instrumentation key. Passed to the platform container via APPINSIGHTS:INSTRUMENTATIONKEY.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -236,6 +240,8 @@ runs:
 
     - name: Generate container secrets
       shell: pwsh
+      env:
+        APPINSIGHTS_INSTRUMENTATION_KEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
       run: |
         function New-RandomPassword {
           # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
@@ -254,6 +260,11 @@ runs:
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
         $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:GITHUB_JOB"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
+        $iKey = $env:APPINSIGHTS_INSTRUMENTATION_KEY_INPUT
+        if ($iKey) {
+          Write-Host "::add-mask::$iKey"
+          Add-Content -Path $env:GITHUB_ENV -Value "APPINSIGHTS_INSTRUMENTATIONKEY=$iKey"
+        }
 
     - name: Start database and elasticsearch containers
       env:

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -259,8 +259,17 @@ runs:
         Write-Host "::add-mask::$esPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
-        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT-$env:DB_PROVIDER_INPUT"
+        # ROLE_NAME uniquely identifies this platform container instance in Application
+        # Insights. It's anchored to the database provider because that's the matrix
+        # dimension that produces a distinct platform container. Caller-defined tags
+        # like artifactSuffix (browser/OS/etc.) live in the test action, NOT here — a
+        # single platform may serve many test bundles with the same ROLE_NAME.
+        # Exported via $GITHUB_ENV so downstream actions (e.g. run-pytest-tests) can
+        # surface the same value without recomputing it.
+        $dbSuffix = if ($env:DB_PROVIDER_INPUT) { "-$env:DB_PROVIDER_INPUT" } else { '' }
+        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT$dbSuffix"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
+        Write-Host "Application Insights role name: $roleName"
         $aiKey = $env:APP_INSIGHTS_IKEY_INPUT
         if ($aiKey) {
           Write-Host "::add-mask::$aiKey"

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -169,7 +169,11 @@ runs:
       shell: pwsh
       run: |
         Write-Host "`e[33mInstall Modules step started."
-        New-Item -Path "./" -Name "${{ env.INSTALL_FOLDER}}" -ItemType "directory"
+        # Pre-create the inner `modules/modules` directory so vc-build's default
+        # DiscoveryPath (`./modules` relative to its cwd) already exists on the
+        # first invocation — otherwise vc-build emits a "Discovery path not found"
+        # warning per call, which GH Actions surfaces as a workflow annotation.
+        New-Item -Path "./${{ env.INSTALL_FOLDER}}/modules" -ItemType "directory" -Force | Out-Null
         Push-Location ./${{ env.INSTALL_FOLDER}}
         vc-build install -Edge -skip InstallPlatform
         vc-build install -module VirtoCommerce.Quote VirtoCommerce.XPickup VirtoCommerce.MarketingExperienceApi

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     environment:
-      - APPINSIGHTS:INSTRUMENTATIONKEY=${APPINSIGHTS_INSTRUMENTATIONKEY:-3ff578a1-596f-46b4-b730-87698dc75555}
+      - APPINSIGHTS:INSTRUMENTATIONKEY=${APPINSIGHTS_INSTRUMENTATIONKEY}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     environment:
-      - APPLICATIONINSIGHTS_CONNECTION_STRING=${APPLICATIONINSIGHTS_CONNECTION_STRING}
+      - ApplicationInsights__ConnectionString=${APPLICATIONINSIGHTS_CONNECTION_STRING}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -67,9 +67,11 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     environment:
+      - APPINSIGHTS:INSTRUMENTATIONKEY=${APPINSIGHTS_INSTRUMENTATIONKEY:-3ff578a1-596f-46b4-b730-87698dc75555}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory
+      - VirtoCommerce:ApplicationInsights:RoleName=${ROLE_NAME}
       - Assets:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/assets/
       - Content:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/cms-content/
       - Search:Provider=ElasticSearch8

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     environment:
-      - ApplicationInsights__ConnectionString=${APPLICATIONINSIGHTS_CONNECTION_STRING}
+      - ApplicationInsights:InstrumentationKey=${APPLICATIONINSIGHTS_INSTRUMENTATIONKEY}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory

--- a/docker-env-full/docker-compose.yml
+++ b/docker-env-full/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     ports:
       - "${DOCKER_PLATFORM_PORT:-8090}:80"
     environment:
-      - APPINSIGHTS:INSTRUMENTATIONKEY=${APPINSIGHTS_INSTRUMENTATIONKEY}
+      - APPLICATIONINSIGHTS_CONNECTION_STRING=${APPLICATIONINSIGHTS_CONNECTION_STRING}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -2,12 +2,14 @@ param(
     [string]$platformUrl     = 'http://localhost:8090',
     [string]$adminUsername   = 'admin',
     [string]$adminPassword   = 'store',
-    # Per-phase timeout (auth, single-type reindex, per-type count gate). 5 min is
-    # generous for the seeded dataset (each phase normally completes in seconds); the
-    # main purpose is to bound how long we wait on an upstream platform hang — e.g. the
-    # known IndexProgressHandler.Finish() NullReferenceException that leaves the
-    # notification stuck and the Hangfire job in an automatic-retry loop.
-    [int]   $timeoutSeconds  = 300,
+    # Per-phase timeout (auth, single-type reindex, per-type count gate). The flow
+    # now has up to ~6 phases that could each hit the timeout (5 serialized reindex
+    # phases + count gate); 150s × 6 ≈ 15 min total worst case, matching the legacy
+    # per-phase budget of 900s back when the flow was a single batched reindex.
+    # The main purpose is to bound how long we wait on an upstream platform hang —
+    # e.g. the known IndexProgressHandler.Finish() NullReferenceException that leaves
+    # the notification stuck and the Hangfire job in an automatic-retry loop.
+    [int]   $timeoutSeconds  = 150,
     [int]   $pollIntervalSec = 5,
     # Per-type minimum indexed-document count. Defaults track the current
     # vc-testing-module dataset. Callers can override per environment:
@@ -158,7 +160,7 @@ function Write-IndexCounts {
 function Wait-AllIndexedCountsReady {
     param([string]$token, [hashtable]$minDocCounts)
     if (-not $minDocCounts -or $minDocCounts.Count -eq 0) {
-        Write-Output "Skipping per-type count gate (no minDocCounts configured)."
+        Write-Host "Skipping per-type count gate (no minDocCounts configured)."
         return
     }
     $headers   = @{ 'Authorization' = "Bearer $token" }
@@ -181,14 +183,14 @@ function Wait-AllIndexedCountsReady {
                 }
             }
             if ($missing.Count -eq 0) {
-                Write-Output "All requested document types meet minimum count expectations: $($observed -join ', ')."
+                Write-Host "All requested document types meet minimum count expectations: $($observed -join ', ')."
                 return
             }
             $lastReason = $missing -join '; '
-            Write-Output "Index counts below expected: $lastReason. Retrying in ${pollIntervalSec}s..."
+            Write-Host "Index counts below expected: $lastReason. Retrying in ${pollIntervalSec}s..."
         } catch {
             $lastReason = $_.Exception.Message
-            Write-Output "Transient error reading index state; retrying: $lastReason"
+            Write-Host "Transient error reading index state; retrying: $lastReason"
         }
         Start-Sleep -Seconds $pollIntervalSec
     }

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -2,7 +2,12 @@ param(
     [string]$platformUrl     = 'http://localhost:8090',
     [string]$adminUsername   = 'admin',
     [string]$adminPassword   = 'store',
-    [int]   $timeoutSeconds  = 900,
+    # Per-phase timeout (auth, single-type reindex, count gate, smoke check). 5 min is
+    # generous for the seeded dataset (each phase normally completes in seconds); the
+    # main purpose is to bound how long we wait on an upstream platform hang — e.g. the
+    # known IndexProgressHandler.Finish() NullReferenceException that leaves the
+    # notification stuck and the Hangfire job in an automatic-retry loop.
+    [int]   $timeoutSeconds  = 300,
     [int]   $pollIntervalSec = 5,
     [string]$storeId         = 'store-acme',
     [string]$cultureName     = 'en-US',
@@ -76,8 +81,13 @@ function Start-ReindexDocumentType {
     }
     # Write-Host: this function returns the notification object; Write-Output would pollute it.
     Write-Host "Triggering reindex for $documentType (DeleteExistingIndex=true)..."
+    # Use -InputObject (not pipeline): in PowerShell, `@($x) | ConvertTo-Json` unwraps a
+    # single-element array to its element and emits a JSON object instead of a one-element
+    # JSON array. The controller binds to IndexingOptions[]; an object yields options=null
+    # at the platform side and RunIndexJobAsync throws ArgumentNullException in .Select.
+    $bodyJson = ConvertTo-Json -InputObject $body -Depth 5
     $resp = Invoke-WebRequest -Uri "$platformUrl/api/search/indexes/index" `
-        -Body ($body | ConvertTo-Json) -Headers $headers -Method POST
+        -Body $bodyJson -Headers $headers -Method POST
     return ($resp.Content | ConvertFrom-Json)
 }
 

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -7,7 +7,17 @@ param(
     [string[]]$smokeProductIds = @('smartphone-apple-iphone-17-256gb-black'),
     [string]$storeId           = 'store-acme',
     [string]$cultureName       = 'en-US',
-    [string]$currencyCode      = 'USD'
+    [string]$currencyCode      = 'USD',
+    # Per-type minimum indexed-document count. Callers can pass
+    # stricter expectations, e.g.:
+    #   -minDocCounts @{ Product=166; Category=4; Member=38; CustomerOrder=20; PickupLocation=34 }
+    [hashtable]$minDocCounts   = @{
+        Member         = 38
+        Product        = 166
+        Category       = 4
+        CustomerOrder  = 20
+        PickupLocation = 34
+    }
 )
 
 $ErrorActionPreference = 'Stop'
@@ -114,7 +124,7 @@ function Wait-IndexerFinished {
 
 # Lists per-document-type counts from /api/search/indexes. Useful sanity check after the
 # indexer reports "finished" — if Product is 0 we have a clear, fast diagnostic instead of
-# watching the XAPI smoke check loop spin until timeout.
+# watching the smoke check loop spin until timeout.
 function Write-IndexCounts {
     param([string]$token)
     $headers = @{ 'Authorization' = "Bearer $token" }
@@ -129,10 +139,48 @@ function Write-IndexCounts {
     }
 }
 
-# Direct raw-index read for a single document. Bypasses XAPI's resolver and store/catalog
-# filtering — answers the bare "is doc X in the {type} index?" question. If this finds the
-# product, XAPI failure is a resolver/filter issue. If it doesn't, the indexer skipped the
-# doc despite reporting overall success.
+# Polls /api/search/indexes and asserts that each requested document type has at least
+# its declared minimum indexed-document count. Retries within $timeoutSeconds because
+# index counts can lag slightly behind the indexer's "finished" signal (ES refresh
+# interval). Throws on timeout with a per-type diagnostic.
+function Wait-AllIndexedCountsReady {
+    param([string]$token, [hashtable]$minDocCounts)
+    if (-not $minDocCounts -or $minDocCounts.Count -eq 0) {
+        Write-Output "Skipping per-type count gate (no minDocCounts configured)."
+        return
+    }
+    $headers   = @{ 'Authorization' = "Bearer $token" }
+    $deadline  = (Get-Date).AddSeconds($timeoutSeconds)
+    $lastReason = ''
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $states = (Invoke-WebRequest -Uri "$platformUrl/api/search/indexes" -Headers $headers -Method GET -ErrorAction Stop).Content | ConvertFrom-Json
+            $byType = @{}
+            foreach ($s in @($states)) { $byType[$s.documentType] = $s }
+            $missing = @()
+            foreach ($key in $minDocCounts.Keys) {
+                $minimum = [long]$minDocCounts[$key]
+                $state   = $byType[$key]
+                $actual  = if ($state -and $null -ne $state.indexedDocumentsCount) { [long]$state.indexedDocumentsCount } else { 0L }
+                if ($actual -lt $minimum) {
+                    $missing += "$key (have $actual, need >= $minimum)"
+                }
+            }
+            if ($missing.Count -eq 0) {
+                Write-Output "All requested document types meet minimum count expectations: $(@($minDocCounts.Keys) -join ', ')."
+                return
+            }
+            $lastReason = $missing -join '; '
+            Write-Output "Index counts below expected: $lastReason. Retrying in ${pollIntervalSec}s..."
+        } catch {
+            $lastReason = $_.Exception.Message
+            Write-Output "Transient error reading index state; retrying: $lastReason"
+        }
+        Start-Sleep -Seconds $pollIntervalSec
+    }
+    throw "Index counts did not satisfy minimum expectations within ${timeoutSeconds}s: $lastReason"
+}
+
 # Polls the raw search index for a product and gates on:
 #   (1) document is present
 #   (2) status contains 'visible'
@@ -202,6 +250,8 @@ Write-Output "Reindex enqueued: notificationId=$($notification.id), jobId=$($not
 Wait-IndexerFinished -token $token -notificationId $notification.id
 
 Write-IndexCounts -token $token
+Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts
+
 foreach ($id in $smokeProductIds) {
     Wait-IndexedProductReady -token $token -documentType 'Product' -documentId $id -currencyCode $currencyCode
 }

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -2,31 +2,15 @@ param(
     [string]$platformUrl     = 'http://localhost:8090',
     [string]$adminUsername   = 'admin',
     [string]$adminPassword   = 'store',
-    # Per-phase timeout (auth, single-type reindex, count gate, smoke check). 5 min is
+    # Per-phase timeout (auth, single-type reindex, per-type count gate). 5 min is
     # generous for the seeded dataset (each phase normally completes in seconds); the
     # main purpose is to bound how long we wait on an upstream platform hang — e.g. the
     # known IndexProgressHandler.Finish() NullReferenceException that leaves the
     # notification stuck and the Hangfire job in an automatic-retry loop.
     [int]   $timeoutSeconds  = 300,
     [int]   $pollIntervalSec = 5,
-    [string]$storeId         = 'store-acme',
-    [string]$cultureName     = 'en-US',
-    [string]$currencyCode    = 'USD',
-    # Per-type smoke IDs — one or more known seeded documents per index type.
-    # Defaults track the current vc-testing-module dataset. Product gets the
-    # full buyability check (status + price + stock); other types only need
-    # presence in the raw index. PickupLocation IDs are platform-generated
-    # (not derived from seed JSON), so it's empty by default and the count
-    # gate below covers that type; callers can opt in by passing IDs.
-    [hashtable]$smokeDocIds  = @{
-        Product        = @('smartphone-apple-iphone-17-256gb-black')
-        Category       = @('category-acme-electronics-smartphones')
-        Member         = @('contact-acme-store-administrator')
-        CustomerOrder  = @('10605003-8a51-44b0-a91c-90b14cdb4a9c')
-        PickupLocation = @()
-    },
-    # Per-type minimum indexed-document count. Callers can pass
-    # stricter expectations, e.g.:
+    # Per-type minimum indexed-document count. Defaults track the current
+    # vc-testing-module dataset. Callers can override per environment:
     #   -minDocCounts @{ Product=166; Category=4; Member=38; CustomerOrder=20; PickupLocation=34 }
     [hashtable]$minDocCounts = @{
         Member         = 38
@@ -127,7 +111,7 @@ function Wait-IndexerFinished {
                         # document types index in parallel. The exception fires in the
                         # progress callback AFTER documents have committed to ES, so the
                         # index state itself is fine. We log a warning instead of failing
-                        # — Wait-IndexedDocumentReady is the authoritative readiness gate.
+                        # — Wait-AllIndexedCountsReady is the authoritative readiness gate.
                         $errList = (@($notif.errors) | Select-Object -First 3) -join ' | '
                         Write-Warning "Indexer reported $errors error(s) (data may still be indexed). First few: $errList"
                     } else {
@@ -152,7 +136,7 @@ function Wait-IndexerFinished {
 
 # Lists per-document-type counts from /api/search/indexes. Useful sanity check after the
 # indexer reports "finished" — if Product is 0 we have a clear, fast diagnostic instead of
-# watching the smoke check loop spin until timeout.
+# watching the count gate spin until timeout.
 function Write-IndexCounts {
     param([string]$token)
     $headers = @{ 'Authorization' = "Bearer $token" }
@@ -211,120 +195,6 @@ function Wait-AllIndexedCountsReady {
     throw "Index counts did not satisfy minimum expectations within ${timeoutSeconds}s: $lastReason"
 }
 
-# Polls the raw search index for a document and asserts readiness:
-#   - For every documentType: the doc must be present.
-#   - For Product specifically: additionally gates on buyability —
-#       status contains 'visible'
-#       price_<currency> > 0
-#       instock_quantity > 0 (or instock = true)
-# Reads the /api/search/indexes/index/{type}/{id} endpoint directly, so this works
-# regardless of the Catalog.Search.UseFullObjectIndexStoring platform setting (which
-# only affects XAPI's __object reconstruction path).
-function Wait-IndexedDocumentReady {
-    param([string]$token, [string]$documentType, [string]$documentId, [string]$currencyCode)
-    $headers    = @{ 'Authorization' = "Bearer $token" }
-    $uri        = "$platformUrl/api/search/indexes/index/$documentType/$documentId"
-    $priceField = "price_$(($currencyCode).ToLower())"   # e.g. 'price_usd'
-    $deadline   = (Get-Date).AddSeconds($timeoutSeconds)
-
-    function Test-Contains($value, [string]$expected) {
-        if ($null -eq $value) { return $false }
-        if ($value -is [array]) { return ($value | ForEach-Object { [string]$_ }) -contains $expected }
-        return [string]$value -eq $expected
-    }
-    function Get-ScalarNumber($value) {
-        if ($null -eq $value) { return 0 }
-        if ($value -is [array]) { return ([double[]]@($value | ForEach-Object { try { [double]$_ } catch { 0 } }) | Measure-Object -Maximum).Maximum }
-        try { return [double]$value } catch { return 0 }
-    }
-
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $docs = (Invoke-WebRequest -Uri $uri -Headers $headers -Method GET -ErrorAction Stop).Content | ConvertFrom-Json
-            if (-not $docs -or @($docs).Count -eq 0) {
-                $lastReason = "no document for $documentType/$documentId in raw index"
-            } elseif ($documentType -eq 'Product') {
-                # Product requires the full buyability check (status + price + stock).
-                $doc       = @($docs)[0]
-                $statusOk  = Test-Contains $doc.status 'visible'
-                $price     = Get-ScalarNumber $doc.$priceField
-                $priceOk   = $price -gt 0
-                $stockQty  = Get-ScalarNumber $doc.instock_quantity
-                $stockFlag = $doc.instock
-                $stockOk   = ($stockQty -gt 0) -or ($stockFlag -eq $true) -or (Test-Contains $stockFlag 'true')
-
-                if ($statusOk -and $priceOk -and $stockOk) {
-                    Write-Output "Product '$documentId' is buyable in the raw index (status=visible, $priceField=$price, instock_quantity=$stockQty)."
-                    return
-                }
-                $missing = @()
-                if (-not $statusOk) { $missing += "status=$($doc.status) (need 'visible')" }
-                if (-not $priceOk)  { $missing += "$priceField=$price (need > 0)" }
-                if (-not $stockOk)  { $missing += "instock_quantity=$stockQty, instock=$stockFlag (need stock > 0)" }
-                $lastReason = "buyability incomplete: $($missing -join '; ')"
-            } else {
-                # Non-Product types: presence in the raw index is sufficient.
-                Write-Output "$documentType '$documentId' is present in the raw index."
-                return
-            }
-        } catch {
-            $lastReason = $_.Exception.Message
-        }
-        Write-Output "Smoke check for '$documentId' not ready: $lastReason. Retrying in ${pollIntervalSec}s..."
-        Start-Sleep -Seconds $pollIntervalSec
-    }
-    throw "$documentType '$documentId' did not become ready in the raw index within ${timeoutSeconds}s: $lastReason"
-}
-
-# Frontend-grade readiness gate. Queries XAPI products(query:) — the exact path the
-# test suite uses (see vc-testing-module/gql/operations/product_operations.py) — and
-# requires:
-#   (1) a matching item with item.code == $productId in the response
-#   (2) availabilityData.isBuyable = true on that item
-# Empirically confirmed to work on ElasticSearch8Provider despite the documented
-# `__object` limitation: separately-indexed fields (name, code, instock_quantity,
-# price_<currency>) populate ExpProduct independently of __object.
-# Failing this gate is the same failure the frontend tests would hit, surfaced
-# early so we don't waste a test run on a broken frontend pipeline.
-function Wait-FrontendProductReady {
-    param([string]$token, [string]$productId, [string]$storeId, [string]$cultureName, [string]$currencyCode)
-    $headers  = @{ Authorization = "Bearer $token"; 'Content-Type' = 'application/json' }
-    $body     = @{
-        query     = 'query($s:String!,$c:String,$cur:String,$q:String,$f:Int){ products(storeId:$s,cultureName:$c,currencyCode:$cur,query:$q,first:$f){ totalCount items { id name code availabilityData { isAvailable isBuyable isInStock availableQuantity } } } }'
-        variables = @{ s = $storeId; c = $cultureName; cur = $currencyCode; q = $productId; f = 10 }
-    } | ConvertTo-Json -Compress
-    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
-    $lastReason = ''
-    while ((Get-Date) -lt $deadline) {
-        try {
-            $resp = (Invoke-WebRequest -Uri "$platformUrl/graphql" -Headers $headers -Method POST -Body $body -ErrorAction Stop).Content | ConvertFrom-Json
-            if ($resp.errors) {
-                # GraphQL server errors (schema/auth/storeId resolution) are not transient — surface and fail fast.
-                $errMsg = ($resp.errors | ForEach-Object { $_.message }) -join '; '
-                throw "GraphQL error for products(query='$productId'): $errMsg"
-            }
-            $items = @($resp.data.products.items)
-            $match = $items | Where-Object { $_.code -eq $productId } | Select-Object -First 1
-            if (-not $match) {
-                $lastReason = "products(query='$productId') returned $($items.Count) item(s); none had code=$productId"
-            } elseif (-not $match.availabilityData -or -not $match.availabilityData.isBuyable) {
-                $a = $match.availabilityData
-                $lastReason = "frontend found '$productId' but not buyable (isAvailable=$($a.isAvailable), isInStock=$($a.isInStock), availableQuantity=$($a.availableQuantity))"
-            } else {
-                Write-Output "Frontend XAPI gate passed for '$productId' via products(query:) (isBuyable=true, availableQuantity=$($match.availabilityData.availableQuantity))."
-                return
-            }
-        } catch {
-            # Re-throw GraphQL-error wrapping immediately; only retry transport-level failures.
-            if ($_.Exception.Message -like 'GraphQL error*') { throw }
-            $lastReason = $_.Exception.Message
-        }
-        Write-Output "Frontend gate for '$productId' not ready: $lastReason. Retrying in ${pollIntervalSec}s..."
-        Start-Sleep -Seconds $pollIntervalSec
-    }
-    throw "Frontend XAPI gate failed for '$productId' within ${timeoutSeconds}s: $lastReason"
-}
-
 $token = Get-AdminToken
 
 # Reindex one document type at a time. See Start-ReindexDocumentType for the rationale —
@@ -342,16 +212,4 @@ foreach ($docType in $script:reindexDocumentTypes) {
 Write-IndexCounts -token $token
 Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts
 
-foreach ($docType in $smokeDocIds.Keys) {
-    foreach ($id in @($smokeDocIds[$docType])) {
-        # Raw-index gate first: fast, no auth/store dependency. If this fails the indexer
-        # didn't write the doc — Wait-FrontendProductReady below would be misleading.
-        Wait-IndexedDocumentReady -token $token -documentType $docType -documentId $id -currencyCode $currencyCode
-        # Frontend gate: only meaningful for Product (XAPI products(query:) returns
-        # catalog items). Other types are validated by the raw-index check above.
-        if ($docType -eq 'Product') {
-            Wait-FrontendProductReady -token $token -productId $id -storeId $storeId -cultureName $cultureName -currencyCode $currencyCode
-        }
-    }
-}
 Write-Output "Indexing complete and verified — safe to start tests."

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -276,6 +276,55 @@ function Wait-IndexedDocumentReady {
     throw "$documentType '$documentId' did not become ready in the raw index within ${timeoutSeconds}s: $lastReason"
 }
 
+# Frontend-grade readiness gate. Queries XAPI products(query:) — the exact path the
+# test suite uses (see vc-testing-module/gql/operations/product_operations.py) — and
+# requires:
+#   (1) a matching item with item.code == $productId in the response
+#   (2) availabilityData.isBuyable = true on that item
+# Empirically confirmed to work on ElasticSearch8Provider despite the documented
+# `__object` limitation: separately-indexed fields (name, code, instock_quantity,
+# price_<currency>) populate ExpProduct independently of __object.
+# Failing this gate is the same failure the frontend tests would hit, surfaced
+# early so we don't waste a test run on a broken frontend pipeline.
+function Wait-FrontendProductReady {
+    param([string]$token, [string]$productId, [string]$storeId, [string]$cultureName, [string]$currencyCode)
+    $headers  = @{ Authorization = "Bearer $token"; 'Content-Type' = 'application/json' }
+    $body     = @{
+        query     = 'query($s:String!,$c:String,$cur:String,$q:String,$f:Int){ products(storeId:$s,cultureName:$c,currencyCode:$cur,query:$q,first:$f){ totalCount items { id name code availabilityData { isAvailable isBuyable isInStock availableQuantity } } } }'
+        variables = @{ s = $storeId; c = $cultureName; cur = $currencyCode; q = $productId; f = 10 }
+    } | ConvertTo-Json -Compress
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    $lastReason = ''
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $resp = (Invoke-WebRequest -Uri "$platformUrl/graphql" -Headers $headers -Method POST -Body $body -ErrorAction Stop).Content | ConvertFrom-Json
+            if ($resp.errors) {
+                # GraphQL server errors (schema/auth/storeId resolution) are not transient — surface and fail fast.
+                $errMsg = ($resp.errors | ForEach-Object { $_.message }) -join '; '
+                throw "GraphQL error for products(query='$productId'): $errMsg"
+            }
+            $items = @($resp.data.products.items)
+            $match = $items | Where-Object { $_.code -eq $productId } | Select-Object -First 1
+            if (-not $match) {
+                $lastReason = "products(query='$productId') returned $($items.Count) item(s); none had code=$productId"
+            } elseif (-not $match.availabilityData -or -not $match.availabilityData.isBuyable) {
+                $a = $match.availabilityData
+                $lastReason = "frontend found '$productId' but not buyable (isAvailable=$($a.isAvailable), isInStock=$($a.isInStock), availableQuantity=$($a.availableQuantity))"
+            } else {
+                Write-Output "Frontend XAPI gate passed for '$productId' via products(query:) (isBuyable=true, availableQuantity=$($match.availabilityData.availableQuantity))."
+                return
+            }
+        } catch {
+            # Re-throw GraphQL-error wrapping immediately; only retry transport-level failures.
+            if ($_.Exception.Message -like 'GraphQL error*') { throw }
+            $lastReason = $_.Exception.Message
+        }
+        Write-Output "Frontend gate for '$productId' not ready: $lastReason. Retrying in ${pollIntervalSec}s..."
+        Start-Sleep -Seconds $pollIntervalSec
+    }
+    throw "Frontend XAPI gate failed for '$productId' within ${timeoutSeconds}s: $lastReason"
+}
+
 $token = Get-AdminToken
 
 # Reindex one document type at a time. See Start-ReindexDocumentType for the rationale —
@@ -295,7 +344,14 @@ Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts
 
 foreach ($docType in $smokeDocIds.Keys) {
     foreach ($id in @($smokeDocIds[$docType])) {
+        # Raw-index gate first: fast, no auth/store dependency. If this fails the indexer
+        # didn't write the doc — Wait-FrontendProductReady below would be misleading.
         Wait-IndexedDocumentReady -token $token -documentType $docType -documentId $id -currencyCode $currencyCode
+        # Frontend gate: only meaningful for Product (XAPI products(query:) returns
+        # catalog items). Other types are validated by the raw-index check above.
+        if ($docType -eq 'Product') {
+            Wait-FrontendProductReady -token $token -productId $id -storeId $storeId -cultureName $cultureName -currencyCode $currencyCode
+        }
     }
 }
 Write-Output "Indexing complete and verified — safe to start tests."

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -56,20 +56,26 @@ function Get-AdminToken {
 
 $script:reindexDocumentTypes = @('Member', 'Product', 'Category', 'CustomerOrder', 'PickupLocation')
 
-# Triggers a full rebuild (DeleteExistingIndex=$true) so every seeded record is re-emitted
-# into a clean index. Returns the IndexProgressPushNotification — its 'id' is what we poll
-# below to know when the indexer truly finished.
-function Start-FullReindex {
-    param([string]$token)
-    $body = $script:reindexDocumentTypes | ForEach-Object {
-        @{ DocumentType = $_; DeleteExistingIndex = $true }
-    }
+# Triggers a reindex (DeleteExistingIndex=$true) for ONE document type and returns
+# the IndexProgressPushNotification — its 'id' is what we poll to know when the
+# indexer truly finished.
+#
+# Why per-type and not batched: VC's IndexingJobs.RunIndexJobAsync runs all submitted
+# options in Task.WhenAll, and the shared IndexProgressHandler holds non-concurrent
+# Dictionary<string,long>'s. Submitting >1 type per POST races the dictionary writes
+# and intermittently corrupts state mid-indexation — one type's task throws while
+# others may have not even started. Serializing here (1 type per POST, wait for
+# Finished between submissions) eliminates the race entirely; the platform's
+# distributed "IndexationJob" lock already enforces one-at-a-time anyway.
+function Start-ReindexDocumentType {
+    param([string]$token, [string]$documentType)
+    $body = @( @{ DocumentType = $documentType; DeleteExistingIndex = $true } )
     $headers = @{
         'Content-Type'  = 'application/json-patch+json'
         'Authorization' = "Bearer $token"
     }
     # Write-Host: this function returns the notification object; Write-Output would pollute it.
-    Write-Host "Triggering full reindex (DeleteExistingIndex=true) of $($body.Count) document types: $($script:reindexDocumentTypes -join ', ')..."
+    Write-Host "Triggering reindex for $documentType (DeleteExistingIndex=true)..."
     $resp = Invoke-WebRequest -Uri "$platformUrl/api/search/indexes/index" `
         -Body ($body | ConvertTo-Json) -Headers $headers -Method POST
     return ($resp.Content | ConvertFrom-Json)
@@ -261,13 +267,18 @@ function Wait-IndexedDocumentReady {
 }
 
 $token = Get-AdminToken
-$notification = Start-FullReindex -token $token
-if (-not $notification.id) {
-    throw "Reindex POST returned no notification id. Response: $($notification | ConvertTo-Json -Depth 5)"
-}
-Write-Output "Reindex enqueued: notificationId=$($notification.id), jobId=$($notification.jobId)"
 
-Wait-IndexerFinished -token $token -notificationId $notification.id
+# Reindex one document type at a time. See Start-ReindexDocumentType for the rationale —
+# batching all 5 types into one POST trips an upstream race condition in the indexer's
+# progress handler that intermittently corrupts the indexation of a random type.
+foreach ($docType in $script:reindexDocumentTypes) {
+    $notification = Start-ReindexDocumentType -token $token -documentType $docType
+    if (-not $notification.id) {
+        throw "Reindex POST for $docType returned no notification id. Response: $($notification | ConvertTo-Json -Depth 5)"
+    }
+    Write-Output "Reindex enqueued for ${docType}: notificationId=$($notification.id), jobId=$($notification.jobId)"
+    Wait-IndexerFinished -token $token -notificationId $notification.id
+}
 
 Write-IndexCounts -token $token
 Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -1,17 +1,29 @@
 param(
-    [string]$platformUrl       = 'http://localhost:8090',
-    [string]$adminUsername     = 'admin',
-    [string]$adminPassword     = 'store',
-    [int]   $timeoutSeconds    = 900,
-    [int]   $pollIntervalSec   = 5,
-    [string[]]$smokeProductIds = @('smartphone-apple-iphone-17-256gb-black'),
-    [string]$storeId           = 'store-acme',
-    [string]$cultureName       = 'en-US',
-    [string]$currencyCode      = 'USD',
+    [string]$platformUrl     = 'http://localhost:8090',
+    [string]$adminUsername   = 'admin',
+    [string]$adminPassword   = 'store',
+    [int]   $timeoutSeconds  = 900,
+    [int]   $pollIntervalSec = 5,
+    [string]$storeId         = 'store-acme',
+    [string]$cultureName     = 'en-US',
+    [string]$currencyCode    = 'USD',
+    # Per-type smoke IDs — one or more known seeded documents per index type.
+    # Defaults track the current vc-testing-module dataset. Product gets the
+    # full buyability check (status + price + stock); other types only need
+    # presence in the raw index. PickupLocation IDs are platform-generated
+    # (not derived from seed JSON), so it's empty by default and the count
+    # gate below covers that type; callers can opt in by passing IDs.
+    [hashtable]$smokeDocIds  = @{
+        Product        = @('smartphone-apple-iphone-17-256gb-black')
+        Category       = @('category-acme-electronics-smartphones')
+        Member         = @('contact-acme-store-administrator')
+        CustomerOrder  = @('10605003-8a51-44b0-a91c-90b14cdb4a9c')
+        PickupLocation = @()
+    },
     # Per-type minimum indexed-document count. Callers can pass
     # stricter expectations, e.g.:
     #   -minDocCounts @{ Product=166; Category=4; Member=38; CustomerOrder=20; PickupLocation=34 }
-    [hashtable]$minDocCounts   = @{
+    [hashtable]$minDocCounts = @{
         Member         = 38
         Product        = 166
         Category       = 4
@@ -99,7 +111,7 @@ function Wait-IndexerFinished {
                         # document types index in parallel. The exception fires in the
                         # progress callback AFTER documents have committed to ES, so the
                         # index state itself is fine. We log a warning instead of failing
-                        # — Wait-IndexedProductReady is the authoritative readiness gate.
+                        # — Wait-IndexedDocumentReady is the authoritative readiness gate.
                         $errList = (@($notif.errors) | Select-Object -First 3) -join ' | '
                         Write-Warning "Indexer reported $errors error(s) (data may still be indexed). First few: $errList"
                     } else {
@@ -183,15 +195,16 @@ function Wait-AllIndexedCountsReady {
     throw "Index counts did not satisfy minimum expectations within ${timeoutSeconds}s: $lastReason"
 }
 
-# Polls the raw search index for a product and gates on:
-#   (1) document is present
-#   (2) status contains 'visible'
-#   (3) instock_quantity > 0 (or instock = true)
-#   (4) price_<currency> > 0
-# Reads the same /api/search/indexes/index/{type}/{id} endpoint used for diagnostics —
-# does NOT depend on XAPI's __object reconstruction, so this works regardless of the
-# Catalog.Search.UseFullObjectIndexStoring platform setting.
-function Wait-IndexedProductReady {
+# Polls the raw search index for a document and asserts readiness:
+#   - For every documentType: the doc must be present.
+#   - For Product specifically: additionally gates on buyability —
+#       status contains 'visible'
+#       price_<currency> > 0
+#       instock_quantity > 0 (or instock = true)
+# Reads the /api/search/indexes/index/{type}/{id} endpoint directly, so this works
+# regardless of the Catalog.Search.UseFullObjectIndexStoring platform setting (which
+# only affects XAPI's __object reconstruction path).
+function Wait-IndexedDocumentReady {
     param([string]$token, [string]$documentType, [string]$documentId, [string]$currencyCode)
     $headers    = @{ 'Authorization' = "Bearer $token" }
     $uri        = "$platformUrl/api/search/indexes/index/$documentType/$documentId"
@@ -214,7 +227,8 @@ function Wait-IndexedProductReady {
             $docs = (Invoke-WebRequest -Uri $uri -Headers $headers -Method GET -ErrorAction Stop).Content | ConvertFrom-Json
             if (-not $docs -or @($docs).Count -eq 0) {
                 $lastReason = "no document for $documentType/$documentId in raw index"
-            } else {
+            } elseif ($documentType -eq 'Product') {
+                # Product requires the full buyability check (status + price + stock).
                 $doc       = @($docs)[0]
                 $statusOk  = Test-Contains $doc.status 'visible'
                 $price     = Get-ScalarNumber $doc.$priceField
@@ -232,6 +246,10 @@ function Wait-IndexedProductReady {
                 if (-not $priceOk)  { $missing += "$priceField=$price (need > 0)" }
                 if (-not $stockOk)  { $missing += "instock_quantity=$stockQty, instock=$stockFlag (need stock > 0)" }
                 $lastReason = "buyability incomplete: $($missing -join '; ')"
+            } else {
+                # Non-Product types: presence in the raw index is sufficient.
+                Write-Output "$documentType '$documentId' is present in the raw index."
+                return
             }
         } catch {
             $lastReason = $_.Exception.Message
@@ -239,7 +257,7 @@ function Wait-IndexedProductReady {
         Write-Output "Smoke check for '$documentId' not ready: $lastReason. Retrying in ${pollIntervalSec}s..."
         Start-Sleep -Seconds $pollIntervalSec
     }
-    throw "Product '$documentId' did not become buyable in the raw index within ${timeoutSeconds}s: $lastReason"
+    throw "$documentType '$documentId' did not become ready in the raw index within ${timeoutSeconds}s: $lastReason"
 }
 
 $token = Get-AdminToken
@@ -254,7 +272,9 @@ Wait-IndexerFinished -token $token -notificationId $notification.id
 Write-IndexCounts -token $token
 Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts
 
-foreach ($id in $smokeProductIds) {
-    Wait-IndexedProductReady -token $token -documentType 'Product' -documentId $id -currencyCode $currencyCode
+foreach ($docType in $smokeDocIds.Keys) {
+    foreach ($id in @($smokeDocIds[$docType])) {
+        Wait-IndexedDocumentReady -token $token -documentType $docType -documentId $id -currencyCode $currencyCode
+    }
 }
 Write-Output "Indexing complete and verified — safe to start tests."

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -158,16 +158,18 @@ function Wait-AllIndexedCountsReady {
             $byType = @{}
             foreach ($s in @($states)) { $byType[$s.documentType] = $s }
             $missing = @()
+            $observed = @()
             foreach ($key in $minDocCounts.Keys) {
                 $minimum = [long]$minDocCounts[$key]
                 $state   = $byType[$key]
                 $actual  = if ($state -and $null -ne $state.indexedDocumentsCount) { [long]$state.indexedDocumentsCount } else { 0L }
+                $observed += "$key($actual)"
                 if ($actual -lt $minimum) {
                     $missing += "$key (have $actual, need >= $minimum)"
                 }
             }
             if ($missing.Count -eq 0) {
-                Write-Output "All requested document types meet minimum count expectations: $(@($minDocCounts.Keys) -join ', ')."
+                Write-Output "All requested document types meet minimum count expectations: $($observed -join ', ')."
                 return
             }
             $lastReason = $missing -join '; '

--- a/docker-env/scripts/common-packages-list.ps1
+++ b/docker-env/scripts/common-packages-list.ps1
@@ -310,6 +310,11 @@ if ($null -eq $packages["VirtoCommerce.XPickup"]) {
     $packages["VirtoCommerce.XPickup"] = "VirtoCommerce.XPickup_$($($edgePackages | Where-Object { $_.Id -eq 'VirtoCommerce.XPickup' } | Select-Object -ExpandProperty Versions)[0].Version).zip"
     $packageSources["VirtoCommerce.XPickup"] = "script:fixed"
 }
+# add VirtoCommerce.MarketingExperienceApi module required for some tests
+if ($null -eq $packages["VirtoCommerce.MarketingExperienceApi"]) {
+    $packages["VirtoCommerce.MarketingExperienceApi"] = "VirtoCommerce.MarketingExperienceApi_$($($edgePackages | Where-Object { $_.Id -eq 'VirtoCommerce.MarketingExperienceApi' } | Select-Object -ExpandProperty Versions)[0].Version).zip"
+    $packageSources["VirtoCommerce.MarketingExperienceApi"] = "script:fixed"
+}
 
 # process the initial first custom module
 ProcessCustomModule -CustomModuleId $customModuleId -CustomModuleUrl $customModuleUrl

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -327,3 +327,10 @@ runs:
         echo "::group::Elasticsearch logs"
         docker logs virtocommerce-es-1 --tail 50
         echo "::endgroup::"
+
+    - name: Log Application Insights role name
+      if: always()
+      shell: bash
+      run: |
+        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        echo "::notice title=Application Insights role name::${role_name}"

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -56,6 +56,14 @@ inputs:
     required: false
     default: ''
     type: string
+  appInsightsResourceId:
+    description: |
+      Azure resource ID of the Application Insights component, e.g.
+      `/subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.insights/components/<name>`.
+      When set, a Logs blade link pre-filtered by cloud_RoleName is appended to the role-name notice.
+    required: false
+    default: ''
+    type: string
 runs:
   using: "composite"
   steps:
@@ -331,6 +339,16 @@ runs:
     - name: Log Application Insights role name
       if: always()
       shell: bash
+      env:
+        APP_INSIGHTS_RESOURCE_ID: ${{ inputs.appInsightsResourceId }}
       run: |
-        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-        echo "::notice title=Application Insights role name::${role_name}"
+        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+        msg="${role_name}"
+        if [ -n "$APP_INSIGHTS_RESOURCE_ID" ]; then
+          kql="union * | where cloud_RoleName == \"${role_name}\" | order by timestamp desc"
+          q=$(printf '%s' "$kql" | gzip -c | base64 -w0 | sed -e 's/+/%2B/g' -e 's|/|%2F|g' -e 's/=/%3D/g')
+          res_enc=$(printf '%s' "$APP_INSIGHTS_RESOURCE_ID" | sed 's|/|%2F|g')
+          url="https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/${res_enc}/source/LogsBlade.AnalyticsShareLinkToQuery/q/${q}/timespan/PT24H"
+          msg="${role_name} — Logs: ${url}"
+        fi
+        echo "::notice title=Application Insights role name::${msg}"

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -331,9 +331,14 @@ runs:
     - name: Log Application Insights role name
       if: always()
       shell: bash
-      env:
-        ARTIFACT_SUFFIX: ${{ inputs.artifactSuffix }}
       run: |
-        suffix="${ARTIFACT_SUFFIX#-}"
-        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}${suffix:+-${suffix}}"
-        echo "::notice title=Application Insights role name::${role_name}"
+        # ROLE_NAME is produced by docker-env-full's 'Generate container secrets'
+        # step (the same value passed to the platform container as
+        # VirtoCommerce:ApplicationInsights:RoleName). We read it from $GITHUB_ENV
+        # rather than recomputing — recomputing risks divergence from what was
+        # actually sent to Application Insights.
+        if [ -n "$ROLE_NAME" ]; then
+          echo "::notice title=Application Insights role name::${ROLE_NAME}"
+        else
+          echo "::warning title=Application Insights role name::ROLE_NAME is unset — docker-env-full did not run in this job, or did not export ROLE_NAME"
+        fi

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -56,14 +56,6 @@ inputs:
     required: false
     default: ''
     type: string
-  appInsightsResourceId:
-    description: |
-      Azure resource ID of the Application Insights component, e.g.
-      `/subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.insights/components/<name>`.
-      When set, a Logs blade link pre-filtered by cloud_RoleName is appended to the role-name notice.
-    required: false
-    default: ''
-    type: string
 runs:
   using: "composite"
   steps:
@@ -340,17 +332,8 @@ runs:
       if: always()
       shell: bash
       env:
-        APP_INSIGHTS_RESOURCE_ID: ${{ inputs.appInsightsResourceId }}
         ARTIFACT_SUFFIX: ${{ inputs.artifactSuffix }}
       run: |
         suffix="${ARTIFACT_SUFFIX#-}"
         role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}${suffix:+-${suffix}}"
-        if [ -n "$APP_INSIGHTS_RESOURCE_ID" ]; then
-          kql="union * | where cloud_RoleName == \"${role_name}\" | order by timestamp desc"
-          q=$(printf '%s' "$kql" | gzip -c | base64 -w0 | sed -e 's/+/%2B/g' -e 's|/|%2F|g' -e 's/=/%3D/g')
-          res_enc=$(printf '%s' "$APP_INSIGHTS_RESOURCE_ID" | sed 's|/|%2F|g')
-          url="https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/${res_enc}/source/LogsBlade.AnalyticsShareLinkToQuery/q/${q}/timespan/PT24H"
-          echo "::notice title=Application Insights role name::${role_name} — Logs: ${url}"
-        else
-          echo "::warning title=Application Insights role name::${role_name} (no link — appInsightsResourceId secret is unset; ensure the calling workflow forwards it via 'secrets:' or 'secrets: inherit')"
-        fi
+        echo "::notice title=Application Insights role name::${role_name}"

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -341,14 +341,16 @@ runs:
       shell: bash
       env:
         APP_INSIGHTS_RESOURCE_ID: ${{ inputs.appInsightsResourceId }}
+        ARTIFACT_SUFFIX: ${{ inputs.artifactSuffix }}
       run: |
-        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
-        msg="${role_name}"
+        suffix="${ARTIFACT_SUFFIX#-}"
+        role_name="vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}${suffix:+-${suffix}}"
         if [ -n "$APP_INSIGHTS_RESOURCE_ID" ]; then
           kql="union * | where cloud_RoleName == \"${role_name}\" | order by timestamp desc"
           q=$(printf '%s' "$kql" | gzip -c | base64 -w0 | sed -e 's/+/%2B/g' -e 's|/|%2F|g' -e 's/=/%3D/g')
           res_enc=$(printf '%s' "$APP_INSIGHTS_RESOURCE_ID" | sed 's|/|%2F|g')
           url="https://portal.azure.com/#blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/${res_enc}/source/LogsBlade.AnalyticsShareLinkToQuery/q/${q}/timespan/PT24H"
-          msg="${role_name} — Logs: ${url}"
+          echo "::notice title=Application Insights role name::${role_name} — Logs: ${url}"
+        else
+          echo "::warning title=Application Insights role name::${role_name} (no link — appInsightsResourceId secret is unset; ensure the calling workflow forwards it via 'secrets:' or 'secrets: inherit')"
         fi
-        echo "::notice title=Application Insights role name::${msg}"


### PR DESCRIPTION
## Summary

Adds Application Insights telemetry to the e2e Docker stack, rewrites `start-indexing.ps1` to dodge a known upstream platform race, and silences a `vc-build` warning. Also adds `VirtoCommerce.MarketingExperienceApi` to the bundled module set.

## Changes

### Application Insights telemetry (new opt-in)
- **`docker-env-full/action.yml`** — new optional input `appInsightsInstrumentationKey`. When set, it's masked via `::add-mask::`, exported to `$GITHUB_ENV`, and forwarded to the platform container as `ApplicationInsights:InstrumentationKey`. Routed through step-level `env:` rather than `${{ inputs… }}` interpolation in the script body (no command-injection vector).
- **`ROLE_NAME`** is computed once in the same step (`vc-platform-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}[-${databaseProvider}]`) and exported via `$GITHUB_ENV`. Consumed by docker-compose (`VirtoCommerce:ApplicationInsights:RoleName`) and by `run-pytest-tests` as a workflow `::notice::` so the role name is one click away from any failing run.
- **`docker-env-full/docker-compose.yml`** — adds the two env vars to `vc-platform-web`. Default empty values keep AI disabled when the key isn't passed.

### `start-indexing.ps1` rewrite
- **One document type per POST** (instead of a single batched call). Avoids an upstream race in `IndexProgressHandler.Progress` where parallel `Task.WhenAll` tasks corrupt a shared `Dictionary<string,long>`. The platform's distributed `IndexationJob` lock already enforces one-at-a-time, so serializing here aligns with that contract.
- **Body shape fix** — `ConvertTo-Json -InputObject $body -Depth 5` instead of pipeline form. PS's pipeline unwraps a one-element array to its element, which the controller binds to `null` and fails in `RunIndexJobAsync` with `ArgumentNullException`.
- **Per-type count gate** (`Wait-AllIndexedCountsReady`) is now the sole readiness signal. Reads `/api/search/indexes` and asserts each requested doc type meets a configurable minimum. Smoke-product / XAPI checks were removed — the count gate is the more direct signal and storefront-specific issues belong in the test suite itself.
- **`Wait-IndexerFinished` softened to warn (not fail) on indexer `errorCount > 0`** — the upstream race fires *after* documents commit, so the index state is fine and the count gate gives the authoritative readiness signal.
- **Per-phase timeout** dropped from 900s → 150s. Worst-case wall time (~6 phases × 150s = ~15 min) matches the legacy single-phase budget.
- Removed parameters: `smokeProductIds`, `storeId`, `cultureName`, `currencyCode`.
- Added parameter: `minDocCounts` (hashtable).

### `vc-build` "Discovery path not found" warning
- **`docker-env-full/action.yml:172`** pre-creates `./modules/modules` before `vc-build install` runs, so its default `DiscoveryPath` exists on the first invocation. Removes 6 spurious warning annotations per CI run (2 vc-build calls × 3 DB matrix dimensions).

### Module bundle
- Adds `VirtoCommerce.MarketingExperienceApi` to both:
  - `docker-env-full/action.yml:175` — `vc-build install -module …`
  - `docker-env/scripts/common-packages-list.ps1:313-317` — fixed-packages map (mirrors the existing `XPickup` entry).

## Caller impact

- **`docker-env-full`** — fully backward-compatible. `appInsightsInstrumentationKey` is optional with safe default; absent → AI disabled.
- **`run-pytest-tests`** — additive (`Log Application Insights role name` step only). No input/output changes.
- **`start-indexing.ps1`** — **breaking parameter change** for any external workflow vendoring this script (e.g. via `wget` from a pinned ref). Removed: `smokeProductIds`, `storeId`, `cultureName`, `currencyCode`. Added: `minDocCounts`. Internal repo callers (`run-pytest-tests/action.yml`) updated.

## Test plan

- [x] Local end-to-end run against `docker-env-full` stack — 5 doc types serialized reindex completes; count gate passes when `XPickup` registers `PickupLocation` correctly, surfaces a precise per-type diagnostic when it doesn't (known XPickup 3.1001.0 limitation in older module versions).
- [x] Independent fresh-eyes code review run via subagent — no blockers; minor suggestions applied (per-phase timeout math, `Write-Host` consistency in `Wait-AllIndexedCountsReady`).
- [x] CI run with `appInsightsInstrumentationKey` set → confirm telemetry flows to Application Insights under the expected `cloud_RoleName`.
- [ ] CI run *without* `appInsightsInstrumentationKey` → confirm no degradation, AI vars are empty, role-name notice still surfaces.

## Known limitations

- `ROLE_NAME` is anchored only to `databaseProvider`. If a future matrix dimension produces distinct platform containers (e.g. `prebuiltImageArtifact` variants), role names will collide across runs and Application Insights will conflate them. Widen the suffix at that point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI orchestration and the search reindexing readiness gate, which can affect e2e stability and failure modes across all DB matrix runs.
> 
> **Overview**
> Adds **optional Application Insights wiring** to the e2e Docker stack: `docker-env-full` accepts an `appInsightsInstrumentationKey`, exports/masks it, computes and exports a stable `ROLE_NAME`, and forwards both into the platform container via `docker-compose.yml`; `run-pytest-tests` now always logs the `ROLE_NAME` as a workflow notice for easier correlation.
> 
> Refactors `start-indexing.ps1` to **serialize reindexing per document type** (and fixes JSON body shaping), reduces timeouts to per-phase budgets, and replaces the prior smoke-product readiness check with a **minimum per-type indexed-document count gate** from `/api/search/indexes`. Also silences `vc-build` discovery-path warnings by pre-creating `modules/modules`, and expands the bundled module set to include `VirtoCommerce.MarketingExperienceApi`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d902a9a9a9d872c17cc7587347c2fb3b01544d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->