### PR TITLE
VCST-5155: Add skipDocCountVerification to bypass count gate for empty document types

### DIFF
--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -201,6 +201,15 @@ function Wait-AllIndexedCountsReady {
     throw "Index counts did not satisfy minimum expectations within ${timeoutSeconds}s: $lastReason"
 }
 
+# Fail loud on typos before the (~15min) reindex loop: a value in
+# -skipDocCountVerification that doesn't match a key in -minDocCounts would
+# silently no-op, and the user would only notice 15min later when the count
+# gate they thought they'd bypassed times out.
+$unknownSkips = @($skipDocCountVerification | Where-Object { $_ -and ($minDocCounts.Keys -notcontains $_) })
+if ($unknownSkips.Count -gt 0) {
+    throw "skipDocCountVerification contains unknown document type(s): $($unknownSkips -join ', '). Valid types: $(($minDocCounts.Keys | Sort-Object) -join ', ')."
+}
+
 $token = Get-AdminToken
 
 # Reindex one document type at a time. See Start-ReindexDocumentType for the rationale —
@@ -216,14 +225,6 @@ foreach ($docType in $script:reindexDocumentTypes) {
 }
 
 Write-IndexCounts -token $token
-
-# Fail loud on typos: a value in -skipDocCountVerification that doesn't match a
-# key in -minDocCounts would silently no-op, and the user would only notice 15min
-# later when the count gate they thought they'd bypassed times out.
-$unknownSkips = @($skipDocCountVerification | Where-Object { $_ -and ($minDocCounts.Keys -notcontains $_) })
-if ($unknownSkips.Count -gt 0) {
-    throw "skipDocCountVerification contains unknown document type(s): $($unknownSkips -join ', '). Valid types: $(($minDocCounts.Keys | Sort-Object) -join ', ')."
-}
 
 $effectiveMinDocCounts = @{}
 foreach ($key in $minDocCounts.Keys) {

--- a/docker-env-full/scripts/start-indexing.ps1
+++ b/docker-env-full/scripts/start-indexing.ps1
@@ -20,7 +20,11 @@ param(
         Category       = 4
         CustomerOrder  = 20
         PickupLocation = 34
-    }
+    },
+    # Document types whose count gate should be skipped (reindex still runs).
+    # Use when the dataset legitimately has 0 source records for a type — e.g.
+    #   -skipDocCountVerification PickupLocation,ContentFile
+    [string[]]$skipDocCountVerification = @()
 )
 
 $ErrorActionPreference = 'Stop'
@@ -212,6 +216,24 @@ foreach ($docType in $script:reindexDocumentTypes) {
 }
 
 Write-IndexCounts -token $token
-Wait-AllIndexedCountsReady -token $token -minDocCounts $minDocCounts
+
+# Fail loud on typos: a value in -skipDocCountVerification that doesn't match a
+# key in -minDocCounts would silently no-op, and the user would only notice 15min
+# later when the count gate they thought they'd bypassed times out.
+$unknownSkips = @($skipDocCountVerification | Where-Object { $_ -and ($minDocCounts.Keys -notcontains $_) })
+if ($unknownSkips.Count -gt 0) {
+    throw "skipDocCountVerification contains unknown document type(s): $($unknownSkips -join ', '). Valid types: $(($minDocCounts.Keys | Sort-Object) -join ', ')."
+}
+
+$effectiveMinDocCounts = @{}
+foreach ($key in $minDocCounts.Keys) {
+    if ($skipDocCountVerification -notcontains $key) {
+        $effectiveMinDocCounts[$key] = $minDocCounts[$key]
+    }
+}
+if ($skipDocCountVerification.Count -gt 0) {
+    Write-Host "Skipping count verification for: $($skipDocCountVerification -join ', ')"
+}
+Wait-AllIndexedCountsReady -token $token -minDocCounts $effectiveMinDocCounts
 
 Write-Output "Indexing complete and verified — safe to start tests."

--- a/run-e2e-tests/action.yml
+++ b/run-e2e-tests/action.yml
@@ -37,6 +37,11 @@ inputs:
     description: 'UI tests repository branch'
     required: true
     type: string
+  skipDocCountVerification:
+    description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+    required: false
+    default: ''
+    type: string
 runs:
   using: "composite"
   steps:
@@ -99,7 +104,16 @@ runs:
         }
         python -m dataset.dataset_manager --seed
         wget https://raw.githubusercontent.com/VirtoCommerce/vc-github-actions/refs/heads/master/docker-env-full/scripts/start-indexing.ps1
-        ./start-indexing.ps1 -platformUrl http://localhost:8090 -adminUsername admin -adminPassword $adminPassword
+        $startArgs = @{
+          platformUrl   = 'http://localhost:8090'
+          adminUsername = 'admin'
+          adminPassword = $adminPassword
+        }
+        $skipRaw = '${{ inputs.skipDocCountVerification }}'
+        if ($skipRaw) {
+          $startArgs.skipDocCountVerification = $skipRaw -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        }
+        ./start-indexing.ps1 @startArgs
 
     - name: Upload dataset_manager log
       if: always()

--- a/run-graphql-tests/action.yml
+++ b/run-graphql-tests/action.yml
@@ -37,6 +37,11 @@ inputs:
     description: 'UI tests repository branch'
     required: true
     type: string
+  skipDocCountVerification:
+    description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+    required: false
+    default: ''
+    type: string
 runs:
   using: "composite"
   steps:
@@ -99,7 +104,16 @@ runs:
         }
         python -m dataset.dataset_manager --seed
         wget https://raw.githubusercontent.com/VirtoCommerce/vc-github-actions/refs/heads/master/docker-env-full/scripts/start-indexing.ps1
-        ./start-indexing.ps1 -platformUrl http://localhost:8090 -adminUsername admin -adminPassword $adminPassword
+        $startArgs = @{
+          platformUrl   = 'http://localhost:8090'
+          adminUsername = 'admin'
+          adminPassword = $adminPassword
+        }
+        $skipRaw = '${{ inputs.skipDocCountVerification }}'
+        if ($skipRaw) {
+          $startArgs.skipDocCountVerification = $skipRaw -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        }
+        ./start-indexing.ps1 @startArgs
 
     - name: Upload dataset_manager log
       if: always()

--- a/run-pytest-tests/action.yml
+++ b/run-pytest-tests/action.yml
@@ -30,6 +30,11 @@ inputs:
     required: false
     default: ''
     type: string
+  skipDocCountVerification:
+    description: 'Comma-separated document types whose post-reindex count check should be skipped (reindex still runs). Use when the seed dataset has 0 records for a type. Example: ''PickupLocation'' or ''PickupLocation,ContentFile''.'
+    required: false
+    default: ''
+    type: string
   testSecretEnvFile:
     description: 'Test secret environment file content'
     required: true
@@ -134,7 +139,16 @@ runs:
         Write-Host "::group::Seed dataset"
         python -m dataset.dataset_manager --seed --mode ci
         Write-Host "::endgroup::"
-        & "${{ github.action_path }}/../docker-env-full/scripts/start-indexing.ps1" -platformUrl "${{ inputs.backUrl }}" -adminUsername "${{ inputs.adminUsername }}" -adminPassword $env:ADMIN_PASSWORD
+        $startArgs = @{
+          platformUrl   = '${{ inputs.backUrl }}'
+          adminUsername = '${{ inputs.adminUsername }}'
+          adminPassword = $env:ADMIN_PASSWORD
+        }
+        $skipRaw = '${{ inputs.skipDocCountVerification }}'
+        if ($skipRaw) {
+          $startArgs.skipDocCountVerification = $skipRaw -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+        }
+        & "${{ github.action_path }}/../docker-env-full/scripts/start-indexing.ps1" @startArgs
 
     - name: Run GraphQL tests
       shell: bash


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">start-indexing.ps1</code> post-reindex count gate currently fails when the seed dataset has zero source records for a document type (e.g. <code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PickupLocation</code>) — the index reports <code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">0 docs</code>, the configured minimum (<code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">34</code>) is never reached, and the gate spins for ~15 min before timing out. This PR adds an opt-in skip list so callers can bypass the count check for known-empty types while still triggering the reindex.</p><h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><ul style="padding-inline-start: 2em; color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><a href="vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/docker-env-full/scripts/start-indexing.ps1" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 95, 184);">docker-env-full/scripts/start-indexing.ps1</a></strong><span> </span>— new<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-skipDocCountVerification</code><span> </span>string-array param. Filters<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$minDocCounts</code><span> </span>before<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Wait-AllIndexedCountsReady</code>; reindex itself still runs for every type. Validates each value against<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$minDocCounts.Keys</code><span> </span>and throws on unknown types (typo guard — silent no-op would defeat the whole purpose of the flag).</li><li><strong><a href="vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-pytest-tests/action.yml" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 95, 184);">run-pytest-tests/action.yml</a>,<span> </span><a href="vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-graphql-tests/action.yml" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 95, 184);">run-graphql-tests/action.yml</a>,<span> </span><a href="vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-e2e-tests/action.yml" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 95, 184);">run-e2e-tests/action.yml</a></strong><span> </span>— new<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">skipDocCountVerification</code><span> </span>input (comma-separated, default<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">''</code>). Splatted into the script so the param is omitted when empty — keeps existing master-pinned callers safe.</li></ul><h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Usage</h3><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(255, 255, 255); border-color: rgba(59, 59, 59, 0.2); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-yaml" style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">- uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
  with:
    skipDocCountVerification: PickupLocation        # or 'PickupLocation,ContentFile'
</code></pre></div><h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behaviour</h3>
Input | Result
-- | --
empty (default) | identical to current behaviour
PickupLocation | reindex runs for all 5 types, count gate skips PickupLocation only
PickupLocaiton (typo) | hard fail at script start with: unknown document type(s): PickupLocaiton. Valid types: Category, CustomerOrder, Member, PickupLocation, Product.

<h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Companion PR</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Platform reusable workflows (<a href="https://github.com/VirtoCommerce/.github" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 95, 184); text-decoration: rgb(0, 95, 184);">Platform/.github</a>) need the matching input wired through — separate PR for <code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ui-autotests.yml</code>, <code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">e2e-autotests.yml</code> (<code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pytest-tests.yml</code> already had it).</p><h3 style="color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h3><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(59, 59, 59); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(248, 248, 248); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgba(59, 59, 59, 0.2); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Run<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pytest-tests</code><span> </span>workflow with<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">skipDocCountVerification: PickupLocation</code><span> </span>against the current seed dataset — verify the previous timeout no longer occurs and tests proceed.</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgba(59, 59, 59, 0.2); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Run with<span> </span><code style="font-family: monospace; color: rgb(59, 59, 59); background-color: rgba(0, 0, 0, 0.12); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">skipDocCountVerification: TypoHere</code><span> </span>— verify the script fails fast with the validation message.</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgba(59, 59, 59, 0.2); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Run with the input unset — verify behaviour is unchanged (all 5 types gated).</li></ul><!--EndFragment-->
</body>
</html>Summary
start-indexing.ps1 post-reindex count gate currently fails when the seed dataset has zero source records for a document type (e.g. PickupLocation) — the index reports 0 docs, the configured minimum (34) is never reached, and the gate spins for ~15 min before timing out. This PR adds an opt-in skip list so callers can bypass the count check for known-empty types while still triggering the reindex.

Changes
[docker-env-full/scripts/start-indexing.ps1](vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/docker-env-full/scripts/start-indexing.ps1) — new -skipDocCountVerification string-array param. Filters $minDocCounts before Wait-AllIndexedCountsReady; reindex itself still runs for every type. Validates each value against $minDocCounts.Keys and throws on unknown types (typo guard — silent no-op would defeat the whole purpose of the flag).
[run-pytest-tests/action.yml](vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-pytest-tests/action.yml), [run-graphql-tests/action.yml](vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-graphql-tests/action.yml), [run-e2e-tests/action.yml](vscode-webview://0lvijftllku6uobn7g63ieruin3344hjcl7esocl8cpr96eqi3i4/run-e2e-tests/action.yml) — new skipDocCountVerification input (comma-separated, default ''). Splatted into the script so the param is omitted when empty — keeps existing master-pinned callers safe.
Usage

- uses: VirtoCommerce/vc-github-actions/run-pytest-tests@master
  with:
    skipDocCountVerification: PickupLocation        # or 'PickupLocation,ContentFile'
Behaviour
Input	Result
empty (default)	identical to current behaviour
PickupLocation	reindex runs for all 5 types, count gate skips PickupLocation only
PickupLocaiton (typo)	hard fail at script start with: unknown document type(s): PickupLocaiton. Valid types: Category, CustomerOrder, Member, PickupLocation, Product.
Companion PR
https://github.com/VirtoCommerce/.github/pull/57)](https://github.com/VirtoCommerce/.github/pull/57

Test plan
 Run pytest-tests workflow with skipDocCountVerification: PickupLocation against the current seed dataset — verify the previous timeout no longer occurs and tests proceed.
 Run with skipDocCountVerification: TypoHere — verify the script fails fast with the validation message.
 Run with the input unset — verify behaviour is unchanged (all 5 types gated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/indexing script and composite action wiring only; default empty input preserves existing count verification behavior.
> 
> **Overview**
> Adds an opt-in **`skipDocCountVerification`** path so CI can finish indexing when a seeded document type legitimately has **zero** indexed docs (e.g. `PickupLocation`) without waiting for the post-reindex minimum-count gate to time out.
> 
> **`start-indexing.ps1`** gains `-skipDocCountVerification` (string array). Reindex still runs for all types; only types *not* in the skip list are passed to `Wait-AllIndexedCountsReady`. Unknown skip names fail **before** reindex with a clear error so typos cannot silently no-op.
> 
> **`run-pytest-tests`**, **`run-graphql-tests`**, and **`run-e2e-tests`** expose the same setting as an optional comma-separated workflow input, splatted into the script only when non-empty (default behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2482fa6fe4f88d86f3afc8fb31dcf16a15fffde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->