### PR TITLE
fix(docs-versioned): install pinned deps from vc-docs requirements-docs.txt

### DIFF
--- a/update-virtocommerce-docs-versioned/action.yml
+++ b/update-virtocommerce-docs-versioned/action.yml
@@ -50,11 +50,11 @@ runs:
 
     - name: Install MkDocs and Mike
       shell: bash
+      working-directory: ${{ github.workspace }}/vc-docs
       run: |
-        pip install mkdocs-material mike
-        pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin
-        pip install mkdocs-minify-plugin mkdocs-redirects mkdocs-monorepo-plugin
-        pip install mkdocs-include-markdown-plugin pymdown-extensions jinja2
+        # Install the exact dependency set pinned by vc-docs so the CI build
+        # never drifts from local builds and the Build check workflow.
+        pip install -r requirements-docs.txt
 
     - name: Configure Git
       shell: bash


### PR DESCRIPTION
## Problem

`update-virtocommerce-docs-versioned` installs a hardcoded pip list that has drifted from what vc-docs actually needs. It still installs the old `mkdocs-awesome-pages-plugin`, but vc-docs migrated to **mkdocs-awesome-nav v3** (vc-docs#70) and also relies on `properdocs` (provides `extra_site_name`).

As a result, every `mike deploy` inside `versioned-build-cicd.py` has been aborting since May 29:

```
Config value 'plugins': The "awesome-nav" plugin is not installed
error: Aborted with a configuration error!
❌ Mike deploy failed for platform/developer-guide: Config value 'extra_site_name': Unrecognised configuration name
```

The script swallows these failures, so a broken image is built and pushed, and the `vcpt-license` rollout hangs in `Progressing`/`Degraded` until timeout ([failed run](https://github.com/VirtoCommerce/vc-github-actions/actions/runs/26744412924)). Prod docs are stuck on the May 28 image.

## Fix

Install from `requirements-docs.txt` pinned in the checked-out vc-docs ref instead of a hardcoded list. This keeps the action in lockstep with local builds and the vc-docs Build check workflow (which already installs `-r requirements-docs.txt`).

`mkdocs-monorepo-plugin` is dropped: vc-docs configs explicitly removed it ("NO monorepo" in all root configs).

Related: vc-docs#71 makes the dispatching workflow fail when the downstream cloud deploy fails.