### PR TITLE
Fix remove-file trigger

### DIFF
--- a/.github/workflows/remove-file-from-repos.yml
+++ b/.github/workflows/remove-file-from-repos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
 # Module workflows
-        repoName: [vc-module-assets ]
+        repoName: [vc-module-assets]
         #           ,vc-module-Authorize.Net
         #           ,vc-module-avatax
         #           ,vc-module-azureblob-assets

--- a/.github/workflows/remove-file-from-repos.yml
+++ b/.github/workflows/remove-file-from-repos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
 # Module workflows
-        # repoName: [vc-module-assets
+        repoName: [vc-module-assets ]
         #           ,vc-module-Authorize.Net
         #           ,vc-module-avatax
         #           ,vc-module-azureblob-assets
@@ -84,13 +84,13 @@ jobs:
         ref: '${{ github.event.inputs.branchName }}'
         # token: '${{ env.GITHUB_TOKEN }}'
 
-    - name: Setup Git Credentials
-      uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
-      with:
-        githubToken: ${{ secrets.REPO_TOKEN }}
+    # - name: Setup Git Credentials
+    #   uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
+    #   with:
+    #     githubToken: ${{ secrets.REPO_TOKEN }}
 
-    - name: Remove ${{ github.event.inputs.filePath }} from ${{ matrix.repoName }} repo 
-      run: |
-        git rm ${{ github.event.inputs.filePath }}
-        git commit -m "ci: Remove ${{ github.event.inputs.filePath }} from repo"
-        git push
+    # - name: Remove ${{ github.event.inputs.filePath }} from ${{ matrix.repoName }} repo 
+    #   run: |
+    #     git rm ${{ github.event.inputs.filePath }}
+    #     git commit -m "ci: Remove ${{ github.event.inputs.filePath }} from repo"
+    #     git push


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow edits with removal/push disabled, so no automated repo mutations from this change as merged.
> 
> **Overview**
> Repairs the **`remove-file-from-repos`** workflow so it can run again by fixing the **matrix `repoName`** YAML (was an unclosed `[vc-module-assets`; now a valid single-entry list **`[vc-module-assets]`**).
> 
> The **Setup Git Credentials** step and the **git rm / commit / push** removal step are **commented out**, so a dispatch currently checks out the target repo/branch but does not remove files or push changes until those steps are restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaa6eef1176edbbc70b813ef6893f4d82094be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->