### PR TITLE
VCST-5246: Improve docker-env and docker-env-full actions

### DIFF
--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -122,10 +122,8 @@ runs:
         [[ -n "$image_path" ]] || { echo "::error::no *.tar found in artifact at $ARTIFACT_DIR"; exit 1; }
         load_output=$(docker load -i "$image_path")
         echo "$load_output"
-        # Prefer a Loaded image: line whose repo segment matches the target name,
-        # so multi-tag tars don't have us retag an arbitrary unrelated ref.
-        # `|| true` swallows grep's exit 1 under pipefail when no ref matches —
-        # the next block handles the empty result.
+        # Match the Loaded image line for the target repo so multi-tag tars don't retag
+        # an unrelated ref; `|| true` swallows grep's no-match exit under pipefail.
         target_name="${TARGET%%:*}"
         loaded=$(printf '%s\n' "$load_output" | sed -n 's/^Loaded image: //p' | { grep -E "(^|/)${target_name}:" || true; } | head -n1)
         if [[ -z "$loaded" ]]; then
@@ -169,10 +167,8 @@ runs:
       shell: pwsh
       run: |
         Write-Host "`e[33mInstall Modules step started."
-        # Pre-create the inner `modules/modules` directory so vc-build's default
-        # DiscoveryPath (`./modules` relative to its cwd) already exists on the
-        # first invocation — otherwise vc-build emits a "Discovery path not found"
-        # warning per call, which GH Actions surfaces as a workflow annotation.
+        # Pre-create modules/modules so vc-build's default DiscoveryPath exists on first
+        # run; otherwise it emits a "Discovery path not found" workflow annotation.
         New-Item -Path "./${{ env.INSTALL_FOLDER}}/modules" -ItemType "directory" -Force | Out-Null
         Push-Location ./${{ env.INSTALL_FOLDER}}
         vc-build install -Edge -skip InstallPlatform
@@ -249,8 +245,7 @@ runs:
         DB_PROVIDER_INPUT: ${{ inputs.databaseProvider }}
       run: |
         function New-RandomPassword {
-          # 32 random alnum chars + 'Vc!' prefix to satisfy SQL Server complexity
-          # (upper/lower/digit/symbol) and stay free of connection-string delimiters.
+          # 'Vc!' + 32 alnum chars: meets SQL Server complexity, no conn-string delimiters.
           $alphabet = [char[]]'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
           $bytes = New-Object byte[] 32
           [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
@@ -263,10 +258,8 @@ runs:
         Write-Host "::add-mask::$esPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
-        # ROLE_NAME identifies this platform container in Application Insights. Prefixed
-        # with the repo name so it's recognizable in the AI interface, suffixed with the
-        # db provider (the matrix dimension), and exported via $GITHUB_ENV for downstream
-        # actions (e.g. run-pytest-tests).
+        # ROLE_NAME identifies the container in App Insights: <repo>-<run>-<attempt>-<db>.
+        # Exported via $GITHUB_ENV for downstream actions.
         $repoName = "$env:GITHUB_REPOSITORY".Split('/')[-1]
         $dbSuffix = if ($env:DB_PROVIDER_INPUT) { "-$env:DB_PROVIDER_INPUT" } else { '' }
         $roleName = "$repoName-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT$dbSuffix"
@@ -293,15 +286,13 @@ runs:
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
 
-        # Mount installed modules via a static overlay file instead of installing the
-        # powershell-yaml module from PSGallery and reserializing docker-compose.yml.
+        # Mount installed modules via a static overlay file (no PSGallery powershell-yaml).
         $composeFiles = @('-f', 'docker-compose.yml', '-f', "docker-compose.$env:DB_PROVIDER.yml")
         if ( $env:INSTALL_MODULES -eq 'true' ){
           Write-Host "Mount installed modules via docker-compose.modules.yml overlay"
           $composeFiles += @('-f', 'docker-compose.modules.yml')
         }
-        # Start everything in one pass — the platform's wait-for-it entrypoint already
-        # gates on vc-db:1433 and es:9200, so there's no need to stage db/es separately.
+        # One pass: the platform's wait-for-it entrypoint already gates on vc-db/es.
         Write-Host "::group::Start containers"
         docker compose --project-name virtocommerce $composeFiles up -d
         Write-Host "::endgroup::"

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -278,7 +278,7 @@ runs:
           Add-Content -Path $env:GITHUB_ENV -Value "APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$aiKey"
         }
 
-    - name: Start database and elasticsearch containers
+    - name: Start containers
       env:
         PLATFORM_IMAGE: ${{ inputs.platformImage }}
         PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
@@ -293,38 +293,19 @@ runs:
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
 
+        # Mount installed modules via a static overlay file instead of installing the
+        # powershell-yaml module from PSGallery and reserializing docker-compose.yml.
+        $composeFiles = @('-f', 'docker-compose.yml', '-f', "docker-compose.$env:DB_PROVIDER.yml")
         if ( $env:INSTALL_MODULES -eq 'true' ){
-          Write-Host "Modify docker-compose.yml to mount installed modules"
-          Install-Module -Name powershell-yaml -Force -allowClobber
-          $parsedYaml = Get-Content -Path ./docker-compose.yml -Raw | ConvertFrom-Yaml
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/modules:/opt/virtocommerce/platform/modules')
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/app_data:/opt/virtocommerce/platform/app_data')
-          $parsedYaml | ConvertTo-Yaml | Set-Content ./docker-compose.yml
-          cat ./docker-compose.yml
+          Write-Host "Mount installed modules via docker-compose.modules.yml overlay"
+          $composeFiles += @('-f', 'docker-compose.modules.yml')
         }
-        # Start only the database and elasticsearch containers first
-        Write-Host "::group::Start Database and Elasticsearch containers"
-        docker compose --project-name virtocommerce -f docker-compose.yml -f "docker-compose.$env:DB_PROVIDER.yml" up -d vc-db es
+        # Start everything in one pass — the platform's wait-for-it entrypoint already
+        # gates on vc-db:1433 and es:9200, so there's no need to stage db/es separately.
+        Write-Host "::group::Start containers"
+        docker compose --project-name virtocommerce $composeFiles up -d
         Write-Host "::endgroup::"
-        Write-Host "`e[32mDatabase and Elasticsearch containers started."
-
-    - name: Start remaining containers
-      env:
-        PLATFORM_IMAGE: ${{ inputs.platformImage }}
-        PLATFORM_DOCKER_TAG: ${{ inputs.platformDockerTag }}
-        ENV_DIR: ${{ inputs.envDir }}
-        SENDGRID_API_KEY: ${{ inputs.sendgridApiKey }}
-        DB_PROVIDER: ${{ inputs.databaseProvider }}
-      shell: pwsh
-      working-directory: ${{ github.action_path }}
-      run: |
-        Write-Host "`e[33mStart Remaining Containers step started."
-        $platformContainer = "virtocommerce-vc-platform-web-1"
-        . ../docker-env/scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-        Write-Host "::group::Start Remaining Containers"
-        docker compose --project-name virtocommerce -f docker-compose.yml -f "docker-compose.$env:DB_PROVIDER.yml" up -d
-        Write-Host "::endgroup::"
-        InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0
+        InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 5 -WaitSeconds 0
         Write-Host "`e[32mAll containers started."
         
     - name: Check Installed Modules

--- a/docker-env-full/action.yml
+++ b/docker-env-full/action.yml
@@ -263,13 +263,13 @@ runs:
         Write-Host "::add-mask::$esPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "DB_PASSWORD=$dbPassword"
         Add-Content -Path $env:GITHUB_ENV -Value "ELASTIC_PASSWORD=$esPassword"
-        # ROLE_NAME uniquely identifies this platform container instance in Application
-        # Insights. It's anchored to the database provider because that's the matrix
-        # dimension that produces a distinct platform container.
-        # Exported via $GITHUB_ENV so downstream actions (e.g. run-pytest-tests) can
-        # surface the same value without recomputing it.
+        # ROLE_NAME identifies this platform container in Application Insights. Prefixed
+        # with the repo name so it's recognizable in the AI interface, suffixed with the
+        # db provider (the matrix dimension), and exported via $GITHUB_ENV for downstream
+        # actions (e.g. run-pytest-tests).
+        $repoName = "$env:GITHUB_REPOSITORY".Split('/')[-1]
         $dbSuffix = if ($env:DB_PROVIDER_INPUT) { "-$env:DB_PROVIDER_INPUT" } else { '' }
-        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT$dbSuffix"
+        $roleName = "$repoName-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT$dbSuffix"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
         Write-Host "Application Insights role name: $roleName"
         $aiKey = $env:APP_INSIGHTS_IKEY_INPUT

--- a/docker-env-full/docker-compose.modules.yml
+++ b/docker-env-full/docker-compose.modules.yml
@@ -1,0 +1,14 @@
+# Overlay applied (via `-f`) only when installModules == 'true'.
+# Bind-mounts the modules installed by `vc-build install` into the platform
+# container. Compose merges service `volumes` by container path, so the
+# ./modules/modules bind mount here replaces the named `modules-volume` mount
+# from docker-compose.yml at /opt/virtocommerce/platform/modules.
+#
+# Named `*.modules.yml` rather than `docker-compose.override.yml` on purpose:
+# Compose auto-loads an `override` file even when unwanted (installModules=false),
+# which would mount non-existent ./modules paths.
+services:
+  vc-platform-web:
+    volumes:
+      - ./modules/modules:/opt/virtocommerce/platform/modules
+      - ./modules/app_data:/opt/virtocommerce/platform/app_data

--- a/docker-env/README.md
+++ b/docker-env/README.md
@@ -78,6 +78,12 @@ Runs Docker Environment
     required: true
     default: '.'
 
+### appInsightsInstrumentationKey:
+
+    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`.'
+    required: false
+    default: ''
+
 ## Example of usage
 
 ```yaml

--- a/docker-env/README.md
+++ b/docker-env/README.md
@@ -80,7 +80,7 @@ Runs Docker Environment
 
 ### appInsightsInstrumentationKey:
 
-    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`.'
+    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`. When set, the run waits ~40s at the end so the short-lived container flushes its telemetry.'
     required: false
     default: ''
 

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: true
     default: '.'
   appInsightsInstrumentationKey:
-    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`.'
+    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`. When set, the run waits ~40s at the end so the short-lived container flushes its telemetry.'
     required: false
     default: ''
 
@@ -67,10 +67,8 @@ runs:
       shell: pwsh
       run: |
         Write-Host "`e[33mInstall Modules step started."
-        # Pre-create the inner `modules/modules` directory so vc-build's default
-        # DiscoveryPath (`./modules` relative to its cwd) already exists on the
-        # first invocation — otherwise vc-build emits a "Discovery path not found"
-        # warning per call, which GH Actions surfaces as a workflow annotation.
+        # Pre-create modules/modules so vc-build's default DiscoveryPath exists on first
+        # run; otherwise it emits a "Discovery path not found" workflow annotation.
         New-Item -Path "./${{ env.INSTALL_FOLDER}}/modules" -ItemType "directory" -Force | Out-Null
         Push-Location ./${{ env.INSTALL_FOLDER}}
         vc-build install -Edge -skip InstallPlatform
@@ -143,17 +141,14 @@ runs:
         Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-        # Mount installed modules via a static overlay file instead of installing the
-        # powershell-yaml module from PSGallery and reserializing docker-compose.yml
-        # on every run.
+        # Mount installed modules via a static overlay file (no PSGallery powershell-yaml).
         $composeFiles = @('-f', 'docker-compose.yml')
         echo "inputs.installModules is ${{ inputs.installModules }}"
         if ( '${{ inputs.installModules }}' -eq 'true' ){
           Write-Host "Mount installed modules via docker-compose.modules.yml overlay"
           $composeFiles += @('-f', 'docker-compose.modules.yml')
         }
-        # Start the swagger validator now so it warms up while the platform boots,
-        # instead of pulling/starting it and sleeping on the critical path later.
+        # Start the validator now so it warms up during platform boot (no sleep later).
         if ( '${{ inputs.validateSwagger }}' -eq 'true' ){
           Write-Host "::group::Start swagger validator"
           docker run -d -p 85:8080 swaggerapi/swagger-validator-v2
@@ -194,10 +189,8 @@ runs:
         . "${{ github.action_path }}/scripts/watch-url-up.ps1"
         $platformIsUp = (Watch-Url-Up -ApiUrl http://localhost:8090 -TimeoutMinutes 15 -RetrySeconds 5 -WaitSeconds 0 -ContainerId $platformContainer)
         if ($platformIsUp) {
-          # The validator container was started during "Start containers" so it could
-          # warm up while the platform booted. Poll it briefly instead of sleeping a
-          # fixed 30s. -SkipHttpErrorCheck means only a refused connection retries;
-          # any HTTP response (even an error) proves the server is listening.
+          # Validator was started during "Start containers"; poll briefly instead of a
+          # fixed sleep. -SkipHttpErrorCheck: any HTTP response (even an error) = listening.
           Write-Host "`e[33mWait for swagger validator on http://localhost:85 to respond."
           $validatorReady = $false
           foreach ($i in 1..20) {
@@ -214,9 +207,8 @@ runs:
           if (-not $validatorReady) {
             Write-Host "`e[33mSwagger validator did not respond in time; attempting validation anyway."
           }
-          # Fetch quietly: -Verbose/-Debug would echo the full HTTP response body and
-          # dump the entire swagger schema (tens of thousands of lines) into the log.
-          # The full schema is published below only when validation fails.
+          # Fetch quietly: -Verbose/-Debug dumps the whole schema into the log. The full
+          # schema is published below only on validation failure.
           ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json
           Get-Content -Path ${{ github.action_path }}/swaggerSchema.json -TotalCount 10
           vc-build ValidateSwaggerSchema -SwaggerSchemaPath ${{ github.action_path }}/swaggerSchema.json -SwaggerValidatorUri http://localhost:85/validator/debug
@@ -232,14 +224,12 @@ runs:
         Write-Host "`e[32mSwagger Schema validated."
 
     - name: Flush Application Insights telemetry
-      # The platform serves for only a few seconds before the job ends, so the AI SDK
-      # (ServerTelemetryChannel, ~30s batch interval) is killed before it transmits.
-      # Keep it alive one batch interval so the timer fires while still running. The
-      # proper fix is a Flush()+sleep on shutdown in vc-module-app-insights (tracked
-      # separately). Runs even on failure; only when AI is configured.
+      # The platform is killed within seconds of the job ending — before the AI SDK's
+      # ~30s batch flushes. Keep it alive one batch interval so telemetry transmits.
+      # Proper fix: Flush()+sleep on shutdown in vc-module-app-insights. Runs on failure too.
       if: ${{ always() && inputs.appInsightsInstrumentationKey != '' }}
       shell: pwsh
       run: |
-        $flushSeconds = 30
+        $flushSeconds = 40
         Write-Host "`e[33mWaiting ${flushSeconds}s for the platform to flush Application Insights telemetry."
         Start-Sleep -Seconds $flushSeconds

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -220,7 +220,7 @@ runs:
           ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json
           Get-Content -Path ${{ github.action_path }}/swaggerSchema.json -TotalCount 10
           vc-build ValidateSwaggerSchema -SwaggerSchemaPath ${{ github.action_path }}/swaggerSchema.json -SwaggerValidatorUri http://localhost:85/validator/debug
-          $validateExitCode = 1 #$LASTEXITCODE
+          $validateExitCode = $LASTEXITCODE
           if ($validateExitCode -ne 0) {
             # Validation failed — surface the full schema (collapsed) for diagnosis.
             Write-Host "::group::Swagger schema (full) — published because validation failed"
@@ -240,6 +240,6 @@ runs:
       if: ${{ always() && inputs.appInsightsInstrumentationKey != '' }}
       shell: pwsh
       run: |
-        $flushSeconds = 40
+        $flushSeconds = 20
         Write-Host "`e[33mWaiting ${flushSeconds}s for the platform to flush Application Insights telemetry."
         Start-Sleep -Seconds $flushSeconds

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -143,20 +143,26 @@ runs:
         Write-Host "`e[33mStart Containers step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . ./scripts/inspect-docker-status.ps1 -ContainerId $platformContainer
-        # for the case of install modules
+        # Mount installed modules via a static overlay file instead of installing the
+        # powershell-yaml module from PSGallery and reserializing docker-compose.yml
+        # on every run.
+        $composeFiles = @('-f', 'docker-compose.yml')
         echo "inputs.installModules is ${{ inputs.installModules }}"
         if ( '${{ inputs.installModules }}' -eq 'true' ){
-          Write-host "Start modify docker-compose.yml"
-          Install-Module -Name powershell-yaml -Force -allowClobber
-          $parsedYaml = Get-Content -Path ./docker-compose.yml -Raw | ConvertFrom-Yaml 
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/modules:/opt/virtocommerce/platform/modules')
-          $parsedYaml.services.'vc-platform-web'.volumes.Add('./modules/app_data:/opt/virtocommerce/platform/app_data')
-          $parsedYaml | ConvertTo-Yaml | Set-Content ./docker-compose.yml
+          Write-Host "Mount installed modules via docker-compose.modules.yml overlay"
+          $composeFiles += @('-f', 'docker-compose.modules.yml')
+        }
+        # Start the swagger validator now so it warms up while the platform boots,
+        # instead of pulling/starting it and sleeping on the critical path later.
+        if ( '${{ inputs.validateSwagger }}' -eq 'true' ){
+          Write-Host "::group::Start swagger validator"
+          docker run -d -p 85:8080 swaggerapi/swagger-validator-v2
+          Write-Host "::endgroup::"
         }
         Write-Host "::group::Start containers"
-        docker compose --project-name virtocommerce up -d
+        docker compose --project-name virtocommerce $composeFiles up -d
         Write-Host "::endgroup::"
-        InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 15 -WaitSeconds 0
+        InspectContainerStatus -ContainerId $platformContainer -TimeoutMinutes 5 -RetrySeconds 5 -WaitSeconds 0
         Write-Host "`e[32mContainers started."
         
     - name: Check Installed Modules
@@ -183,16 +189,28 @@ runs:
       if: ${{ inputs.validateSwagger == 'true' }}
       shell: pwsh
       run: |
-        $waitForSwaggerSec = 30
         Write-Host "`e[33mSwagger Schema Validation step started."
         $platformContainer = "virtocommerce-vc-platform-web-1"
         . "${{ github.action_path }}/scripts/watch-url-up.ps1"
-        $platformIsUp = (Watch-Url-Up -ApiUrl http://localhost:8090 -TimeoutMinutes 15 -RetrySeconds 15 -WaitSeconds 0 -ContainerId $platformContainer)
+        $platformIsUp = (Watch-Url-Up -ApiUrl http://localhost:8090 -TimeoutMinutes 15 -RetrySeconds 5 -WaitSeconds 0 -ContainerId $platformContainer)
         if ($platformIsUp) {
-          docker pull swaggerapi/swagger-validator-v2
-          docker run -d -p 85:8080 swaggerapi/swagger-validator-v2
-          Write-Host "`e[33mWait before swagger-validator-v2 start for $waitForSwaggerSec seconds."
-          Start-Sleep -Seconds $waitForSwaggerSec
+          # The validator container was started during "Start containers" so it could
+          # warm up while the platform booted. Poll it briefly instead of sleeping a
+          # fixed 30s. -SkipHttpErrorCheck means only a refused connection retries;
+          # any HTTP response (even an error) proves the server is listening.
+          $validatorReady = $false
+          foreach ($i in 1..20) {
+            try {
+              Invoke-WebRequest -Uri "http://localhost:85/" -Method Get -TimeoutSec 5 -SkipHttpErrorCheck | Out-Null
+              $validatorReady = $true
+              break
+            } catch {
+              Start-Sleep -Seconds 2
+            }
+          }
+          if (-not $validatorReady) {
+            Write-Host "`e[33mSwagger validator did not respond in time; attempting validation anyway."
+          }
           ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json -Verbose -Debug
           Get-ChildItem
           Get-ChildItem ${{ github.action_path }}

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -220,7 +220,7 @@ runs:
           ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json
           Get-Content -Path ${{ github.action_path }}/swaggerSchema.json -TotalCount 10
           vc-build ValidateSwaggerSchema -SwaggerSchemaPath ${{ github.action_path }}/swaggerSchema.json -SwaggerValidatorUri http://localhost:85/validator/debug
-          $validateExitCode = $LASTEXITCODE
+          $validateExitCode = 1 #$LASTEXITCODE
           if ($validateExitCode -ne 0) {
             # Validation failed — surface the full schema (collapsed) for diagnosis.
             Write-Host "::group::Swagger schema (full) — published because validation failed"

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -240,6 +240,6 @@ runs:
       if: ${{ always() && inputs.appInsightsInstrumentationKey != '' }}
       shell: pwsh
       run: |
-        $flushSeconds = 20
+        $flushSeconds = 30
         Write-Host "`e[33mWaiting ${flushSeconds}s for the platform to flush Application Insights telemetry."
         Start-Sleep -Seconds $flushSeconds

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -198,23 +198,46 @@ runs:
           # warm up while the platform booted. Poll it briefly instead of sleeping a
           # fixed 30s. -SkipHttpErrorCheck means only a refused connection retries;
           # any HTTP response (even an error) proves the server is listening.
+          Write-Host "`e[33mWait for swagger validator on http://localhost:85 to respond."
           $validatorReady = $false
           foreach ($i in 1..20) {
             try {
               Invoke-WebRequest -Uri "http://localhost:85/" -Method Get -TimeoutSec 5 -SkipHttpErrorCheck | Out-Null
               $validatorReady = $true
+              Write-Host "`e[32mSwagger validator is up (attempt $i)."
               break
             } catch {
+              Write-Host "Swagger validator not ready yet (attempt $i of 20); retrying in 2s..."
               Start-Sleep -Seconds 2
             }
           }
           if (-not $validatorReady) {
             Write-Host "`e[33mSwagger validator did not respond in time; attempting validation anyway."
           }
-          ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json -Verbose -Debug
-          Get-ChildItem
-          Get-ChildItem ${{ github.action_path }}
+          # Fetch quietly: -Verbose/-Debug would echo the full HTTP response body and
+          # dump the entire swagger schema (tens of thousands of lines) into the log.
+          # The full schema is published below only when validation fails.
+          ${{ github.action_path }}/scripts/get-swagger.ps1 -ApiUrl http://localhost:8090 -OutFile ${{ github.action_path }}/swaggerSchema.json
           Get-Content -Path ${{ github.action_path }}/swaggerSchema.json -TotalCount 10
           vc-build ValidateSwaggerSchema -SwaggerSchemaPath ${{ github.action_path }}/swaggerSchema.json -SwaggerValidatorUri http://localhost:85/validator/debug
+          $validateExitCode = $LASTEXITCODE
+          if ($validateExitCode -ne 0) {
+            # Validation failed — surface the full schema (collapsed) for diagnosis.
+            Write-Host "::group::Swagger schema (full) — published because validation failed"
+            Get-Content -Path ${{ github.action_path }}/swaggerSchema.json
+            Write-Host "::endgroup::"
+            exit $validateExitCode
+          }
         }
         Write-Host "`e[32mSwagger Schema validated."
+
+    - name: Flush telemetry (graceful platform shutdown)
+      # The container is short-lived, so it's killed before the AI SDK flushes its
+      # batched telemetry. `docker stop` (SIGTERM + grace) lets the platform shut down
+      # gracefully and flush on dispose. Runs even on failure; only when AI is configured.
+      if: ${{ always() && inputs.appInsightsInstrumentationKey != '' }}
+      shell: pwsh
+      run: |
+        $platformContainer = "virtocommerce-vc-platform-web-1"
+        Write-Host "`e[33mGracefully stopping $platformContainer to flush Application Insights telemetry."
+        docker stop -t 30 $platformContainer

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -231,13 +231,15 @@ runs:
         }
         Write-Host "`e[32mSwagger Schema validated."
 
-    - name: Flush telemetry (graceful platform shutdown)
-      # The container is short-lived, so it's killed before the AI SDK flushes its
-      # batched telemetry. `docker stop` (SIGTERM + grace) lets the platform shut down
-      # gracefully and flush on dispose. Runs even on failure; only when AI is configured.
+    - name: Flush Application Insights telemetry
+      # The platform serves for only a few seconds before the job ends, so the AI SDK
+      # (ServerTelemetryChannel, ~30s batch interval) is killed before it transmits.
+      # Keep it alive one batch interval so the timer fires while still running. The
+      # proper fix is a Flush()+sleep on shutdown in vc-module-app-insights (tracked
+      # separately). Runs even on failure; only when AI is configured.
       if: ${{ always() && inputs.appInsightsInstrumentationKey != '' }}
       shell: pwsh
       run: |
-        $platformContainer = "virtocommerce-vc-platform-web-1"
-        Write-Host "`e[33mGracefully stopping $platformContainer to flush Application Insights telemetry."
-        docker stop -t 30 $platformContainer
+        $flushSeconds = 40
+        Write-Host "`e[33mWaiting ${flushSeconds}s for the platform to flush Application Insights telemetry."
+        Start-Sleep -Seconds $flushSeconds

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -118,12 +118,14 @@ runs:
       env:
         APP_INSIGHTS_IKEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
       run: |
-        # ROLE_NAME uniquely identifies this platform container instance in Application
-        # Insights. Exported via $GITHUB_ENV so downstream actions (e.g. run-pytest-tests)
-        # can surface the same value without recomputing it.
-        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+        # ROLE_NAME identifies this platform container instance in Application Insights.
+        # Prefixed with the repo name so it's recognizable in the AI interface, and
+        # exported via $GITHUB_ENV for downstream actions (e.g. run-pytest-tests).
+        $repoName = "$env:GITHUB_REPOSITORY".Split('/')[-1]
+        $roleName = "$repoName-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
-        Write-Host "Application Insights role name: $roleName"
+        # Surface the role name on the run summary page (annotations section).
+        Write-Host "::notice title=Application Insights role name::$roleName"
         $aiKey = $env:APP_INSIGHTS_IKEY_INPUT
         if ($aiKey) {
           Write-Host "::add-mask::$aiKey"

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -118,11 +118,11 @@ runs:
       env:
         APP_INSIGHTS_IKEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
       run: |
-        # ROLE_NAME identifies this platform container instance in Application Insights.
-        # Prefixed with the repo name so it's recognizable in the AI interface, and
-        # exported via $GITHUB_ENV for downstream actions (e.g. run-pytest-tests).
+        # ROLE_NAME identifies this platform container in Application Insights:
+        # <repo>-<run>-<attempt>-<job>. Exported via $GITHUB_ENV for downstream actions.
         $repoName = "$env:GITHUB_REPOSITORY".Split('/')[-1]
-        $roleName = "$repoName-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+        $jobSuffix = if ($env:GITHUB_JOB) { "-$env:GITHUB_JOB" } else { '' }
+        $roleName = "$repoName-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT$jobSuffix"
         Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
         # Surface the role name on the run summary page (annotations section).
         Write-Host "::notice title=Application Insights role name::$roleName"

--- a/docker-env/action.yml
+++ b/docker-env/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'Directory with environment files'
     required: true
     default: '.'
+  appInsightsInstrumentationKey:
+    description: 'Application Insights instrumentation key (GUID). Passed to the platform container as `ApplicationInsights:InstrumentationKey`.'
+    required: false
+    default: ''
 
 
 runs:
@@ -108,6 +112,23 @@ runs:
         touch ${{ inputs.envDir }}/.docker/platform.env
         echo -e 'Platform environment variables:'
         cat ${{ inputs.envDir }}/.docker/platform.env
+
+    - name: Generate Application Insights configuration
+      shell: pwsh
+      env:
+        APP_INSIGHTS_IKEY_INPUT: ${{ inputs.appInsightsInstrumentationKey }}
+      run: |
+        # ROLE_NAME uniquely identifies this platform container instance in Application
+        # Insights. Exported via $GITHUB_ENV so downstream actions (e.g. run-pytest-tests)
+        # can surface the same value without recomputing it.
+        $roleName = "vc-platform-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+        Add-Content -Path $env:GITHUB_ENV -Value "ROLE_NAME=$roleName"
+        Write-Host "Application Insights role name: $roleName"
+        $aiKey = $env:APP_INSIGHTS_IKEY_INPUT
+        if ($aiKey) {
+          Write-Host "::add-mask::$aiKey"
+          Add-Content -Path $env:GITHUB_ENV -Value "APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$aiKey"
+        }
 
     - name: Start containers
       env:

--- a/docker-env/docker-compose.modules.yml
+++ b/docker-env/docker-compose.modules.yml
@@ -1,0 +1,13 @@
+# Overlay applied (via `-f`) only when installModules == 'true'.
+# Mounts the modules installed by `vc-build install` into the platform container.
+# Compose appends these to the base service's `volumes` list, so the base
+# cms-content mount is preserved.
+#
+# Named `*.modules.yml` rather than `docker-compose.override.yml` on purpose:
+# Compose auto-loads an `override` file even when unwanted (installModules=false),
+# which would mount non-existent ./modules paths.
+services:
+  vc-platform-web:
+    volumes:
+      - ./modules/modules:/opt/virtocommerce/platform/modules
+      - ./modules/app_data:/opt/virtocommerce/platform/app_data

--- a/docker-env/docker-compose.yml
+++ b/docker-env/docker-compose.yml
@@ -35,9 +35,11 @@ services:
     env_file:
       - ${ENV_DIR:-.}/.docker/platform.env
     environment:
+      - ApplicationInsights:InstrumentationKey=${APPLICATIONINSIGHTS_INSTRUMENTATIONKEY}
       - ASPNETCORE_URLS=http://+
       - VirtoCommerce:AllowInsecureHttp=true
       - VirtoCommerce:Hangfire:JobStorageType=Memory
+      - VirtoCommerce:ApplicationInsights:RoleName=${ROLE_NAME}
       - ConnectionStrings:VirtoCommerce=Data Source=vc-db;Initial Catalog=VirtoCommerce3docker;Persist Security Info=True;User ID=sa;Password=v!rto_Labs!;MultipleActiveResultSets=False;Connect Timeout=360;TrustServerCertificate=True;
       - Assets:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/assets/
       - Content:FileSystem:PublicUrl=http://localhost:${DOCKER_PLATFORM_PORT:-8090}/cms-content/

--- a/docker-env/scripts/check-installed-modules.ps1
+++ b/docker-env/scripts/check-installed-modules.ps1
@@ -28,7 +28,7 @@ function Get-AuthToken {
     return $responseContent.access_token
 }
 
-$platformIsUp = (Watch-Url-Up -ApiUrl $ApiUrl -TimeoutMinutes 15 -RetrySeconds 15 -WaitSeconds 15 -ContainerId $ContainerId)
+$platformIsUp = (Watch-Url-Up -ApiUrl $ApiUrl -TimeoutMinutes 15 -RetrySeconds 5 -WaitSeconds 5 -ContainerId $ContainerId)
 
 if ($platformIsUp) {
     $authToken = (Get-AuthToken $appAuthUrl $Username $Password)[1]

--- a/docker-env/scripts/watch-url-up.ps1
+++ b/docker-env/scripts/watch-url-up.ps1
@@ -4,14 +4,20 @@ function Watch-Url-Up {
     (
         [string]$ApiUrl = "http://localhost:8090", # Host URL
         [int]$TimeoutMinutes = 15, # Max period of time for retry attempts in minutes
-        [int]$RetrySeconds = 15, # Period of time between retry attempts in seconds
+        [int]$RetrySeconds = 5, # Period of time between retry attempts in seconds
         [int]$WaitSeconds = 60, # Period of time before start retry attempts in seconds
         [string]$ContainerId = "virtocommerce-vc-platform-web-1" # $ContainerId to write host container log on each 3 unsuccess attempt
     )
 
 
-    $printLogAttempt = 3
-    $restartContainerAttempt = 9
+    # Express the log-dump / force-restart cadence in seconds and derive the attempt
+    # counts from $RetrySeconds, so changing the poll interval doesn't change *when*
+    # (wall-clock) we dump logs or force a restart. Originally 3rd/9th attempt at a
+    # 15s interval => every 45s / 135s.
+    $printLogEverySeconds = 45
+    $restartContainerEverySeconds = 135
+    $printLogAttempt = [math]::Max(1, [int]($printLogEverySeconds / $RetrySeconds))
+    $restartContainerAttempt = [math]::Max(1, [int]($restartContainerEverySeconds / $RetrySeconds))
 
     $responseStatus = 0
     [int]$maxRepeat = $TimeoutMinutes * 60 / $RetrySeconds


### PR DESCRIPTION
1. ROLE_NAME now contains the repository name
2. Slow YAML parsing is replaced with a Docker overlay file
3. Added the configuration for sending telemetry to Application Insights for docker-env in the same way as for auto-tests
4. Write debug info to the CI log only in case of swagger validation errors
5. Refactor to speed up execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how modules are mounted and how the full stack is brought up in CI; mis-merged compose overlays or timing could break installs or readiness checks, and telemetry keys are newly passed into containers (masked in logs).
> 
> **Overview**
> **docker-env** and **docker-env-full** no longer install **powershell-yaml** or rewrite `docker-compose.yml` at runtime when `installModules` is true. They instead pass an optional **`docker-compose.modules.yml`** overlay so module and `app_data` bind mounts apply only when needed (avoiding auto-loaded `override` files).
> 
> **docker-env-full** collapses the previous two-step “DB/ES first, then everything else” flow into a **single** `docker compose up -d`, relying on the platform **wait-for-it** entrypoint for dependencies. Health polling is tightened (**5s** retries, shorter initial waits) and **`watch-url-up.ps1`** keeps the same wall-clock log dump / container restart cadence when the poll interval changes.
> 
> **Application Insights** support is extended for **docker-env** (new `appInsightsInstrumentationKey` input, compose env for instrumentation key and **ROLE_NAME**, a **40s flush** step when a key is set, and README docs). **ROLE_NAME** now includes the **repository name** (and job or DB provider suffix where applicable) instead of a fixed `vc-platform-…` prefix.
> 
> **Swagger validation** starts the validator during container startup, **polls** for readiness instead of a fixed sleep, fetches the schema quietly, and dumps the **full schema only on validation failure**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825094221040f5718ef35587940039e2514eb731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->