### PR TITLE
Serve real 404 and redirect not-found docs paths to root

### DIFF
--- a/update-virtocommerce-docs-versioned/docker/nginx.versioned.conf
+++ b/update-virtocommerce-docs-versioned/docker/nginx.versioned.conf
@@ -27,12 +27,21 @@ server {
     rewrite ^/new/dev_docs/(.*)$ /platform/developer-guide/latest/$1 permanent;
     rewrite ^/new/(.*)$ /$1 permanent;
     
-    # Main location block - simplified like the working config
+    # Main location block. Missing paths return a real 404 (not a soft-200
+    # fallback to the home page). The 404 page redirects visitors to the root.
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ =404;
     }
 
     # Error pages
+    # Any not-found path serves /404.html (baked from the root docs build),
+    # which meta-refreshes the visitor to the documentation root.
+    error_page   404  /404.html;
+    location = /404.html {
+        root   /usr/share/nginx/html;
+        internal;
+    }
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
Companion to the docs 404/redirect change. Makes the versioned docs image return a real 404 for unknown paths instead of silently serving the home page.

## Problem
`nginx.versioned.conf` used `try_files $uri $uri/ /index.html`, so any not-found path (e.g. the legacy `/platform-user-guide/`) fell back to the home page with a **200** status. This is a soft-404: it renders the home template under the wrong URL and keeps dead links indexable.

## Changes
- `try_files $uri $uri/ /index.html` → `try_files $uri $uri/ =404`.
- Add `error_page 404 /404.html` with an internal location, so not-found paths serve `/404.html` (baked into the image from the docs build), which redirects the visitor to the documentation root.

Regex location blocks above (versions.json, version-less to latest 301) match before `location /`, so they are unaffected. Real pages still resolve via `$uri` / `$uri/`.

## Follow-up
Recommend running `nginx -t` in CI before merge (not run locally). Deploys via the docs `@master` action reference, so this must land on `master`.